### PR TITLE
Implement reusable Jinja2 template components with partials

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "unidiff>=0.7.5",
     "Pygments>=2.17.0",
     "MarkupSafe>=2.1.0",
+    "jinja-partials>=0.2.0",
 ]
 
 [project.optional-dependencies]

--- a/src/difflicious/app.py
+++ b/src/difflicious/app.py
@@ -21,6 +21,11 @@ def create_app() -> Flask:
 
     app = Flask(__name__, template_folder=template_dir, static_folder=static_dir)
 
+    # Register jinja-partials extension
+    import jinja_partials  # type: ignore[import-untyped]
+
+    jinja_partials.register_extensions(app)
+
     # Configure logging
     logging.basicConfig(level=logging.INFO)
     logger = logging.getLogger(__name__)

--- a/src/difflicious/templates/index.html
+++ b/src/difflicious/templates/index.html
@@ -1,118 +1,29 @@
 {% extends "base.html" %}
 
 {% block content %}
-<!-- Toolbar -->
-<header class="bg-white border-b border-gray-200 px-4 py-3">
-    <div class="flex items-center justify-between">
-        <div class="flex items-center space-x-4">
-            <h1 class="text-xl font-semibold text-gray-900">Difflicious</h1>
-
-            <!-- Base Branch Dropdown -->
-            <form method="GET" action="/" class="flex items-center space-x-2">
-                <label class="text-sm font-medium text-gray-700">Base:</label>
-                <select name="base_branch" onchange="this.form.submit()"
-                    class="bg-white border border-gray-300 rounded-md px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
-                    {% for branch in branches.all %}
-                    <option value="{{ branch }}" {% if branch == current_base_branch %}selected{% endif %}>
-                        {{ branch }}
-                    </option>
-                    {% endfor %}
-                </select>
-
-                <!-- Diff Options -->
-                <div class="flex items-center space-x-4">
-                    <label class="flex items-center">
-                        <input type="checkbox" name="unstaged" value="true" 
-                               {% if unstaged %}checked{% endif %}
-                               onchange="this.form.submit()"
-                               class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded">
-                        <span class="ml-1 text-sm text-gray-700">Unstaged</span>
-                    </label>
-                    
-                    <label class="flex items-center">
-                        <input type="checkbox" name="untracked" value="true"
-                               {% if untracked %}checked{% endif %}
-                               onchange="this.form.submit()"
-                               class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded">
-                        <span class="ml-1 text-sm text-gray-700">Untracked</span>
-                    </label>
-                </div>
-                
-                <!-- Search Filter -->
-                <input type="text" name="search" value="{{ search_filter or '' }}" 
-                       placeholder="Search files..." 
-                       class="border border-gray-300 rounded-md px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
-            </form>
-        </div>
-
-        <!-- Status -->
-        <div class="flex items-center space-x-4">
-            <div class="text-sm text-gray-600">
-                {{ total_files }} files changed
-            </div>
-            <button onclick="location.reload()" 
-                class="bg-blue-600 text-white px-3 py-1.5 rounded-md text-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500">
-                Refresh
-            </button>
-        </div>
-    </div>
-</header>
+{{ render_partial('partials/toolbar.html', 
+   branches=branches, 
+   current_base_branch=current_base_branch, 
+   unstaged=unstaged, 
+   untracked=untracked, 
+   search_filter=search_filter, 
+   total_files=total_files) }}
 
 <!-- Main Content -->
 <main class="flex-1 overflow-hidden">
     {% if loading %}
-    <!-- Loading State -->
-    <div class="flex items-center justify-center h-full">
-        <div class="text-center">
-            <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mx-auto"></div>
-            <p class="mt-2 text-gray-600">Loading git diff data...</p>
-        </div>
-    </div>
+    {{ render_partial('partials/loading_state.html') }}
     {% elif not groups or not total_files %}
-    <!-- Empty State -->
-    <div class="flex items-center justify-center h-full">
-        <div class="text-center">
-            {% if error %}
-            <div class="text-4xl mb-4">⚠️</div>
-            <h2 class="text-xl font-semibold text-red-600 mb-2">Error</h2>
-            <p class="text-red-500 mb-4">{{ error }}</p>
-            {% else %}
-            <div class="text-6xl mb-4">✨</div>
-            <h2 class="text-xl font-semibold text-gray-900 mb-2">No changes found</h2>
-            {% endif %}
-            <div class="text-gray-600 space-y-2">
-                {% if not unstaged and not untracked %}
-                <p>Enable "Unstaged" or "Untracked" to see changes.</p>
-                {% elif unstaged and not untracked %}
-                <p>No unstaged changes in your working directory.</p>
-                {% elif not unstaged and untracked %}
-                <p>No untracked files found.</p>
-                {% else %}
-                <p>Your working directory is clean - no unstaged or untracked files.</p>
-                {% endif %}
-                {% if current_base_branch != 'main' %}
-                <p class="text-sm text-gray-500 mt-3">
-                    Comparing against branch: <span class="font-mono">{{ current_base_branch }}</span>
-                </p>
-                {% endif %}
-            </div>
-        </div>
-    </div>
+    {{ render_partial('partials/empty_state.html', 
+       error=error, 
+       unstaged=unstaged, 
+       untracked=untracked, 
+       current_base_branch=current_base_branch) }}
     {% else %}
     <!-- Diff Content -->
     <div class="h-full overflow-y-auto">
         <div class="p-4 space-y-6">
-            <!-- Global Controls -->
-            <div class="flex items-center space-x-2 mb-4">
-                <button id="expandAll" onclick="expandAllFiles()" 
-                    class="bg-gray-100 text-gray-700 hover:bg-gray-200 px-3 py-1.5 rounded text-sm focus:outline-none focus:ring-2 focus:ring-gray-400 transition-colors">
-                    Expand All
-                </button>
-                <button id="collapseAll" onclick="collapseAllFiles()"
-                    class="bg-gray-100 text-gray-700 hover:bg-gray-200 px-3 py-1.5 rounded text-sm focus:outline-none focus:ring-2 focus:ring-gray-400 transition-colors">
-                    Collapse All  
-                </button>
-            </div>
+            {{ render_partial('partials/global_controls.html') }}
 
             <!-- Render Diff Groups -->
             {% include "diff_groups.html" %}

--- a/src/difflicious/templates/partials/empty_state.html
+++ b/src/difflicious/templates/partials/empty_state.html
@@ -1,0 +1,29 @@
+<!-- Empty State -->
+<div class="flex items-center justify-center h-full">
+    <div class="text-center">
+        {% if error %}
+        <div class="text-4xl mb-4">⚠️</div>
+        <h2 class="text-xl font-semibold text-red-600 mb-2">Error</h2>
+        <p class="text-red-500 mb-4">{{ error }}</p>
+        {% else %}
+        <div class="text-6xl mb-4">✨</div>
+        <h2 class="text-xl font-semibold text-gray-900 mb-2">No changes found</h2>
+        {% endif %}
+        <div class="text-gray-600 space-y-2">
+            {% if not unstaged and not untracked %}
+            <p>Enable "Unstaged" or "Untracked" to see changes.</p>
+            {% elif unstaged and not untracked %}
+            <p>No unstaged changes in your working directory.</p>
+            {% elif not unstaged and untracked %}
+            <p>No untracked files found.</p>
+            {% else %}
+            <p>Your working directory is clean - no unstaged or untracked files.</p>
+            {% endif %}
+            {% if current_base_branch != 'main' %}
+            <p class="text-sm text-gray-500 mt-3">
+                Comparing against branch: <span class="font-mono">{{ current_base_branch }}</span>
+            </p>
+            {% endif %}
+        </div>
+    </div>
+</div>

--- a/src/difflicious/templates/partials/global_controls.html
+++ b/src/difflicious/templates/partials/global_controls.html
@@ -1,0 +1,11 @@
+<!-- Global Controls -->
+<div class="flex items-center space-x-2 mb-4">
+    <button id="expandAll" onclick="expandAllFiles()"
+        class="bg-gray-100 text-gray-700 hover:bg-gray-200 px-3 py-1.5 rounded text-sm focus:outline-none focus:ring-2 focus:ring-gray-400 transition-colors">
+        Expand All
+    </button>
+    <button id="collapseAll" onclick="collapseAllFiles()"
+        class="bg-gray-100 text-gray-700 hover:bg-gray-200 px-3 py-1.5 rounded text-sm focus:outline-none focus:ring-2 focus:ring-gray-400 transition-colors">
+        Collapse All
+    </button>
+</div>

--- a/src/difflicious/templates/partials/loading_state.html
+++ b/src/difflicious/templates/partials/loading_state.html
@@ -1,0 +1,7 @@
+<!-- Loading State -->
+<div class="flex items-center justify-center h-full">
+    <div class="text-center">
+        <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mx-auto"></div>
+        <p class="mt-2 text-gray-600">Loading git diff data...</p>
+    </div>
+</div>

--- a/src/difflicious/templates/partials/toolbar.html
+++ b/src/difflicious/templates/partials/toolbar.html
@@ -1,0 +1,56 @@
+<!-- Toolbar -->
+<header class="bg-white border-b border-gray-200 px-4 py-3">
+    <div class="flex items-center justify-between">
+        <div class="flex items-center space-x-4">
+            <h1 class="text-xl font-semibold text-gray-900">Difflicious</h1>
+
+            <!-- Base Branch Dropdown -->
+            <form method="GET" action="/" class="flex items-center space-x-2">
+                <label class="text-sm font-medium text-gray-700">Base:</label>
+                <select name="base_branch" onchange="this.form.submit()"
+                    class="bg-white border border-gray-300 rounded-md px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                    {% for branch in branches.all %}
+                    <option value="{{ branch }}" {% if branch == current_base_branch %}selected{% endif %}>
+                        {{ branch }}
+                    </option>
+                    {% endfor %}
+                </select>
+
+                <!-- Diff Options -->
+                <div class="flex items-center space-x-4">
+                    <label class="flex items-center">
+                        <input type="checkbox" name="unstaged" value="true" 
+                               {% if unstaged %}checked{% endif %}
+                               onchange="this.form.submit()"
+                               class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded">
+                        <span class="ml-1 text-sm text-gray-700">Unstaged</span>
+                    </label>
+                    
+                    <label class="flex items-center">
+                        <input type="checkbox" name="untracked" value="true"
+                               {% if untracked %}checked{% endif %}
+                               onchange="this.form.submit()"
+                               class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded">
+                        <span class="ml-1 text-sm text-gray-700">Untracked</span>
+                    </label>
+                </div>
+                
+                <!-- Search Filter -->
+                <input type="text" name="search" value="{{ search_filter or '' }}" 
+                       placeholder="Search files..." 
+                       class="border border-gray-300 rounded-md px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+            </form>
+        </div>
+
+        <!-- Status -->
+        <div class="flex items-center space-x-4">
+            <div class="text-sm text-gray-600">
+                {{ total_files }} files changed
+            </div>
+            <button onclick="location.reload()" 
+                class="bg-blue-600 text-white px-3 py-1.5 rounded-md text-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                Refresh
+            </button>
+        </div>
+    </div>
+</header>

--- a/uv.lock
+++ b/uv.lock
@@ -200,6 +200,7 @@ dependencies = [
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "click", version = "8.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "flask" },
+    { name = "jinja-partials" },
     { name = "markupsafe" },
     { name = "pygments" },
     { name = "unidiff" },
@@ -230,6 +231,7 @@ requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
     { name = "click", specifier = ">=8.0.0" },
     { name = "flask", specifier = ">=2.3.0" },
+    { name = "jinja-partials", specifier = ">=0.2.0" },
     { name = "markupsafe", specifier = ">=2.1.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pygments", specifier = ">=2.17.0" },
@@ -310,6 +312,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
+]
+
+[[package]]
+name = "jinja-partials"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/e2/8e8adedc678e51e5fe1f19e34ae279c558f4912d9b1535832cd3c1d0a6ac/jinja_partials-0.3.0.tar.gz", hash = "sha256:e5f22d272bd47cb0652ca97ec17b9358a1b3daf30efbcabf3ca24c6b0d4923c9", size = 2971077, upload-time = "2025-05-31T17:49:46.761Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/af/6f4edca14ac66b1ab7c57ea0ecd1d938c4cf7c80b20fbb49af06c9662cf0/jinja_partials-0.3.0-py3-none-any.whl", hash = "sha256:023227b66869b29af30f10e52cf7a2260ae7abfa4dcc1fb26e571450dd68bcc3", size = 5362, upload-time = "2025-05-31T17:49:45.024Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add jinja-partials dependency for improved template maintainability
- Extract 4 focused, reusable template components from main index.html
- Reduce main template complexity from 122 to 33 lines (73% reduction)
- Preserve all existing functionality including Alpine.js reactivity

## Components Created
- **Toolbar Component**: Form controls, branch selector, and search functionality
- **Loading State Component**: Loading spinner and message
- **Empty State Component**: No changes found with contextual messaging and error handling
- **Global Controls Component**: Expand/collapse all buttons

## Technical Changes
- Added `jinja-partials>=0.2.0` dependency to pyproject.toml
- Registered jinja-partials extension in Flask app initialization
- Created `templates/partials/` directory structure for organized components
- Updated main template to use `render_partial()` calls with proper data passing
- Added type ignore annotation for untyped library import

## Test plan
- [x] Verify application starts without errors
- [x] Confirm all template rendering works correctly
- [x] Check that all existing functionality is preserved
- [x] Validate mypy type checking passes
- [x] Ensure code formatting and linting standards are met

🤖 Generated with [Claude Code](https://claude.ai/code)