### PR TITLE
Refactor: metadata-first get_diff, base_ref-only (BREAKING), simpler Git ops

### DIFF
--- a/doc/proposals/2025-08-04-2130-simplify-diff-logic-and-ui.md
+++ b/doc/proposals/2025-08-04-2130-simplify-diff-logic-and-ui.md
@@ -1,0 +1,70 @@
+# Proposal: Simplify Diff Logic and UI Rendering
+
+**Date**: 2025-08-04
+
+## 1. Summary
+
+Following the recent refactoring of the `get_diff` method, this proposal outlines a plan to further simplify the implementation, reduce complexity, and improve maintainability. The current system introduced a clearer distinction between "HEAD vs. working dir" and "branch vs. working dir" comparisons, but this has resulted in conditional logic and data transformations in the service and template layers.
+
+This proposal aims to push this complexity further down the stack, resulting in simpler services, dumber templates, and a more elegant and unified control flow.
+
+## 2. Current State Analysis
+
+The recent refactor introduced several new components and logic flows:
+
+*   **Dual Comparison Modes**: The application now operates in two distinct modes: comparing against `HEAD` or comparing against a branch. This is controlled by an `is_head_comparison` flag that is passed through multiple layers.
+*   **Complex Parameter Handling**: The Flask app (`app.py`) and `TemplateRenderingService` contain logic to interpret a `base_commit` parameter and derive the `is_head_comparison` state from it. A `use_head` parameter was also introduced, creating some redundancy.
+*   **Service-Layer Data Transformation**: `TemplateRenderingService` is responsible for transforming the data returned by `DiffService`. Specifically, when not in a HEAD comparison, it combines the `staged` and `unstaged` file groups into a single `changes` group. This adds significant business logic to the rendering layer.
+*   **Conditional Template Logic**: The main toolbar template (`partials/toolbar.html`) contains `if/else` blocks to render different checkboxes based on the `is_head_comparison` flag.
+
+While functional, this approach distributes the core diffing logic across multiple layers (app, services, templates), making the system harder to reason about and maintain.
+
+## 3. Proposed Simplifications
+
+### Proposal 1: Unify Backend Logic with a Single Source of Truth
+
+The `base_commit` parameter, selected by the user in the UI dropdown, should be the single source of truth for the comparison.
+
+*   **Action**: Remove the `use_head` and `is_head_comparison` parameters and flags from all functions and templates.
+*   **Mechanism**: The backend logic, primarily in `git_operations.py`, will inspect the `base_commit` string directly. If `base_commit == 'HEAD'`, it will trigger the HEAD comparison logic. Otherwise, it will perform a branch comparison.
+*   **Benefit**: This eliminates a layer of parameter mapping and state propagation, simplifying the control flow significantly.
+
+### Proposal 2: Push Data Transformation into `GitRepository`
+
+The responsibility for shaping the diff data should belong to the data source (`GitRepository`), not the rendering service.
+
+*   **Action**: Modify `GitRepository.get_diff` to return the data in the exact structure the template needs.
+*   **Mechanism**:
+    *   The `get_diff` method will accept the `base_commit` parameter.
+    *   If `base_commit == 'HEAD'`, it will return a dictionary with `staged` and `unstaged` groups.
+    *   If `base_commit` is a branch name, it will perform the logic to combine staged and unstaged changes internally and return a dictionary with a single `changes` group.
+*   **Benefit**: `TemplateRenderingService` becomes much simpler. It just receives the data and passes it to the template without any structural modification. This adheres to the principle of "fat model, skinny controller/service."
+
+### Proposal 3: Refactor and Simplify Templates
+
+The template logic can be simplified by removing the conditional rendering of the toolbar and making it data-driven.
+
+*   **Action**:
+    1.  Create a new `changes` group in the templates to handle the combined view for branch diffs.
+    2.  Refactor `partials/toolbar.html` to remove the `if/else` block for checkboxes.
+    3.  Create a new data structure in the backend that defines the available filters for each mode.
+*   **Mechanism**:
+    *   The `TemplateRenderingService` will pass a list of available "filter groups" to the template (e.g., `['Unstaged', 'Untracked']` for HEAD, `['Changes', 'Untracked']` for a branch).
+    *   The template will simply loop over this list to render the checkboxes, removing the need for `if/else` logic.
+    *   The `diff_groups.html` template will be updated to iterate over the groups provided, whether that's `['staged', 'unstaged', 'untracked']` or `['changes', 'untracked']`.
+*   **Benefit**: Templates become more declarative and less cluttered with conditional logic, making them easier to read and maintain.
+
+## 4. Benefits of Proposed Changes
+
+*   **Reduced Complexity**: Fewer moving parts and a clearer, more linear data flow.
+*   **Improved Maintainability**: Logic is centralized in the appropriate layers, making it easier to find, understand, and modify.
+*   **Increased Elegance**: The solution will be more cohesive and follow established software design principles (e.g., single source of truth, separation of concerns).
+*   **No User-Facing Changes**: This is a purely internal refactoring that simplifies the codebase without altering the application's functionality.
+
+## 5. Implementation Plan
+
+1.  **Modify `GitRepository.get_diff`**: Update the method to accept `base_commit` and return the correctly structured data (`staged`/`unstaged` for HEAD, `changes` for branches).
+2.  **Simplify `TemplateRenderingService`**: Remove the data transformation logic and the `is_head_comparison` flag. Update it to pass the new filter group structure to the template.
+3.  **Simplify `app.py`**: Remove the redundant parameter handling for `use_head`.
+4.  **Refactor Templates**: Update `toolbar.html` and `diff_groups.html` to use the new, simpler data structures and remove conditional blocks.
+5.  **Update Tests**: Adjust all relevant unit and integration tests to reflect the new, simplified architecture.

--- a/foo
+++ b/foo
@@ -1,1 +1,0 @@
-new content

--- a/foo
+++ b/foo
@@ -1,0 +1,1 @@
+new content

--- a/src/difflicious/app.py
+++ b/src/difflicious/app.py
@@ -38,7 +38,7 @@ def create_app() -> Flask:
             base_branch = request.args.get("base_branch")
             target_commit = request.args.get("target_commit")
             unstaged = request.args.get("unstaged", "true").lower() == "true"
-            staged = request.args.get("staged", "true").lower() == "true"
+            staged = request.args.get("staged", "true").lower() == "true"  
             untracked = request.args.get("untracked", "false").lower() == "true"
             file_path = request.args.get("file")
             search_filter = request.args.get("search", "").strip()

--- a/src/difflicious/app.py
+++ b/src/difflicious/app.py
@@ -35,7 +35,7 @@ def create_app() -> Flask:
         """Main diff visualization page with server-side rendering."""
         try:
             # Get query parameters
-            base_branch = request.args.get("base_branch")
+            base_ref = request.args.get("base_ref")
             target_commit = request.args.get("target_commit")
             unstaged = request.args.get("unstaged", "true").lower() == "true"
             staged = request.args.get("staged", "true").lower() == "true"
@@ -47,7 +47,7 @@ def create_app() -> Flask:
             # Prepare template data
             template_service = TemplateRenderingService()
             template_data = template_service.prepare_diff_data_for_template(
-                base_commit=base_branch,
+                base_commit=base_ref,
                 target_commit=target_commit,
                 unstaged=unstaged,
                 staged=staged,
@@ -55,7 +55,7 @@ def create_app() -> Flask:
                 file_path=file_path,
                 search_filter=search_filter if search_filter else None,
                 expand_files=expand_files,
-                base_ref=base_branch if base_branch and base_branch not in ["HEAD", ""] else None,
+                base_ref=base_ref if base_ref and base_ref not in ["HEAD", ""] else None,
             )
 
             return render_template("index.html", **template_data)
@@ -74,7 +74,7 @@ def create_app() -> Flask:
                 "unstaged": True,
                 "untracked": False,
                 "search_filter": "",
-                "current_base_branch": "main",
+                "current_base_ref": "main",
             }
             return render_template("index.html", **error_data)
 

--- a/src/difflicious/app.py
+++ b/src/difflicious/app.py
@@ -36,7 +36,6 @@ def create_app() -> Flask:
         try:
             # Get query parameters
             base_ref = request.args.get("base_ref")
-            target_commit = request.args.get("target_commit")
             unstaged = request.args.get("unstaged", "true").lower() == "true"
             staged = request.args.get("staged", "true").lower() == "true"
             untracked = request.args.get("untracked", "false").lower() == "true"
@@ -47,15 +46,13 @@ def create_app() -> Flask:
             # Prepare template data
             template_service = TemplateRenderingService()
             template_data = template_service.prepare_diff_data_for_template(
-                base_commit=base_ref,
-                target_commit=target_commit,
+                base_ref=base_ref if base_ref is not None else None,
                 unstaged=unstaged,
                 staged=staged,
                 untracked=untracked,
                 file_path=file_path,
                 search_filter=search_filter if search_filter else None,
                 expand_files=expand_files,
-                base_ref=base_ref if base_ref and base_ref not in ["HEAD", ""] else None,
             )
 
             return render_template("index.html", **template_data)

--- a/src/difflicious/app.py
+++ b/src/difflicious/app.py
@@ -38,7 +38,7 @@ def create_app() -> Flask:
             base_branch = request.args.get("base_branch")
             target_commit = request.args.get("target_commit")
             unstaged = request.args.get("unstaged", "true").lower() == "true"
-            staged = request.args.get("staged", "true").lower() == "true"  
+            staged = request.args.get("staged", "true").lower() == "true"
             untracked = request.args.get("untracked", "false").lower() == "true"
             file_path = request.args.get("file")
             search_filter = request.args.get("search", "").strip()
@@ -240,25 +240,27 @@ def create_app() -> Flask:
         unstaged = request.args.get("unstaged", "true").lower() == "true"
         untracked = request.args.get("untracked", "false").lower() == "true"
         file_path = request.args.get("file")
-        
+
         # Handle both new and legacy parameters
         use_head = request.args.get("use_head", "false").lower() == "true"
         base_commit = request.args.get("base_commit")  # Legacy parameter
-        
+        target_commit = request.args.get("target_commit")  # New parameter
+
         # Map legacy base_commit parameter to use_head logic
         if base_commit:
             # If base_commit is "HEAD" or current branch, use HEAD comparison
             # Otherwise use default branch comparison
             from difflicious.services.git_service import GitService
+
             git_service = GitService()
             repo_info = git_service.get_repository_status()
             current_branch = repo_info.get("current_branch")
-            
+
             use_head = base_commit in ["HEAD", current_branch]
 
         try:
             diff_service = DiffService()
-            
+
             # Map to the legacy DiffService interface (which internally uses new get_diff)
             if use_head:
                 # Working directory vs HEAD comparison
@@ -291,6 +293,7 @@ def create_app() -> Flask:
                     "file_filter": file_path,
                     "use_head": use_head,
                     "base_commit": base_commit,  # Keep for compatibility
+                    "target_commit": target_commit,  # New parameter
                     "total_files": total_files,
                 }
             )

--- a/src/difflicious/app.py
+++ b/src/difflicious/app.py
@@ -275,7 +275,7 @@ def create_app() -> Flask:
                     "untracked": untracked,
                     "file_filter": file_path,
                     "use_head": use_head,
-                        "base_ref": base_ref,
+                    "base_ref": base_ref,
                     "total_files": total_files,
                 }
             )

--- a/src/difflicious/app.py
+++ b/src/difflicious/app.py
@@ -38,6 +38,7 @@ def create_app() -> Flask:
             base_branch = request.args.get("base_branch")
             target_commit = request.args.get("target_commit")
             unstaged = request.args.get("unstaged", "true").lower() == "true"
+            staged = request.args.get("staged", "true").lower() == "true"
             untracked = request.args.get("untracked", "false").lower() == "true"
             file_path = request.args.get("file")
             search_filter = request.args.get("search", "").strip()
@@ -49,6 +50,7 @@ def create_app() -> Flask:
                 base_commit=base_branch,
                 target_commit=target_commit,
                 unstaged=unstaged,
+                staged=staged,
                 untracked=untracked,
                 file_path=file_path,
                 search_filter=search_filter if search_filter else None,

--- a/src/difflicious/git_operations.py
+++ b/src/difflicious/git_operations.py
@@ -212,7 +212,9 @@ class GitRepository:
                 "error": str(e),
             }
 
-    def _resolve_base_ref(self, use_head: bool = False, preferred_ref: Optional[str] = None) -> str:
+    def _resolve_base_ref(
+        self, use_head: bool = False, preferred_ref: Optional[str] = None
+    ) -> str:
         """Resolve the base reference for comparisons.
 
         If use_head is True, return "HEAD". Otherwise, use preferred_ref if provided
@@ -231,7 +233,9 @@ class GitRepository:
             reference_point = "HEAD"
         return str(reference_point)
 
-    def summarize_changes(self, include_unstaged: bool = True, include_untracked: bool = True) -> dict[str, Any]:
+    def summarize_changes(
+        self, include_unstaged: bool = True, include_untracked: bool = True
+    ) -> dict[str, Any]:
         """Return counts of changed files without fetching diff contents.
 
         Returns a dict with the same group keys as get_diff, but only 'count' fields
@@ -248,18 +252,26 @@ class GitRepository:
             if include_untracked:
                 stdout, _, rc = self._execute_git_command(["status", "--porcelain"])
                 if rc == 0 and stdout:
-                    summary["untracked"]["count"] = sum(1 for line in stdout.split("\n") if line.startswith("??"))
+                    summary["untracked"]["count"] = sum(
+                        1 for line in stdout.split("\n") if line.startswith("??")
+                    )
 
             # Unstaged changes (working tree vs index)
             if include_unstaged:
                 stdout, _, rc = self._execute_git_command(["diff", "--name-only"])
                 if rc == 0 and stdout:
-                    summary["unstaged"]["count"] = sum(1 for line in stdout.split("\n") if line.strip())
+                    summary["unstaged"]["count"] = sum(
+                        1 for line in stdout.split("\n") if line.strip()
+                    )
 
             # Staged changes (index vs HEAD)
-            stdout, _, rc = self._execute_git_command(["diff", "--cached", "--name-only", "HEAD"])
+            stdout, _, rc = self._execute_git_command(
+                ["diff", "--cached", "--name-only", "HEAD"]
+            )
             if rc == 0 and stdout:
-                summary["staged"]["count"] = sum(1 for line in stdout.split("\n") if line.strip())
+                summary["staged"]["count"] = sum(
+                    1 for line in stdout.split("\n") if line.strip()
+                )
 
         except GitOperationError as e:
             logger.warning(f"summarize_changes failed: {e}")
@@ -354,9 +366,9 @@ class GitRepository:
                 ["remote", "show", "origin"]
             )
             if return_code == 0 and stdout:
-                for line in stdout.split('\n'):
-                    if 'HEAD branch:' in line:
-                        default_branch = line.split('HEAD branch:')[1].strip()
+                for line in stdout.split("\n"):
+                    if "HEAD branch:" in line:
+                        default_branch = line.split("HEAD branch:")[1].strip()
                         if default_branch in branches:
                             self._cached_default_branch = default_branch
                             return str(default_branch)
@@ -370,7 +382,7 @@ class GitRepository:
             )
             if return_code == 0 and stdout:
                 # Output format: refs/remotes/origin/main
-                default_branch = stdout.strip().split('/')[-1]
+                default_branch = stdout.strip().split("/")[-1]
                 if default_branch in branches:
                     self._cached_default_branch = default_branch
                     return str(default_branch)
@@ -379,16 +391,14 @@ class GitRepository:
 
         # Method 3: Check for origin/HEAD in remote branches
         try:
-            stdout, stderr, return_code = self._execute_git_command(
-                ["branch", "-r"]
-            )
+            stdout, stderr, return_code = self._execute_git_command(["branch", "-r"])
             if return_code == 0 and stdout:
-                for line in stdout.split('\n'):
-                    if 'origin/HEAD' in line:
+                for line in stdout.split("\n"):
+                    if "origin/HEAD" in line:
                         # Extract the branch it points to
-                        parts = line.strip().split(' -> ')
+                        parts = line.strip().split(" -> ")
                         if len(parts) == 2:
-                            default_branch = parts[1].replace('origin/', '')
+                            default_branch = parts[1].replace("origin/", "")
                             if default_branch in branches:
                                 self._cached_default_branch = default_branch
                                 return str(default_branch)
@@ -436,7 +446,9 @@ class GitRepository:
             }
 
             # Resolve base reference
-            reference_point = self._resolve_base_ref(use_head=use_head, preferred_ref=base_ref)
+            reference_point = self._resolve_base_ref(
+                use_head=use_head, preferred_ref=base_ref
+            )
 
             # Untracked files
             if include_untracked:
@@ -461,12 +473,16 @@ class GitRepository:
             # Unstaged (working tree) vs base
             if include_unstaged:
                 base_args_unstaged: list[str] = [] if use_head else [reference_point]
-                unstaged_files = self._collect_diff_metadata(base_args_unstaged, file_path)
+                unstaged_files = self._collect_diff_metadata(
+                    base_args_unstaged, file_path
+                )
                 groups["unstaged"]["files"].extend(unstaged_files)
                 groups["unstaged"]["count"] = len(unstaged_files)
 
             # Staged (index) vs base (HEAD or branch)
-            base_args_staged: list[str] = ["--cached", "HEAD"] if use_head else ["--cached", reference_point]
+            base_args_staged: list[str] = (
+                ["--cached", "HEAD"] if use_head else ["--cached", reference_point]
+            )
             staged_files = self._collect_diff_metadata(base_args_staged, file_path)
             groups["staged"]["files"].extend(staged_files)
             groups["staged"]["count"] = len(staged_files)
@@ -476,11 +492,17 @@ class GitRepository:
             for group_name in ("unstaged", "staged"):
                 for diff_info in groups[group_name]["files"]:
                     if use_head and group_name == "unstaged":
-                        content = self._get_file_diff(diff_info["path"], None, None, False)
+                        content = self._get_file_diff(
+                            diff_info["path"], None, None, False
+                        )
                     elif group_name == "staged":
-                        content = self._get_file_diff(diff_info["path"], None, None, True)
+                        content = self._get_file_diff(
+                            diff_info["path"], None, None, True
+                        )
                     else:
-                        content = self._get_file_diff(diff_info["path"], reference_point, None, False)
+                        content = self._get_file_diff(
+                            diff_info["path"], reference_point, None, False
+                        )
                     diff_info["content"] = content
 
             return groups

--- a/src/difflicious/services/diff_service.py
+++ b/src/difflicious/services/diff_service.py
@@ -46,7 +46,7 @@ class DiffService(BaseService):
             # If base_commit was specified as "HEAD", use use_head=True
             # Otherwise use default branch comparison (use_head=False)
             use_head = base_commit == "HEAD" if base_commit else False
-            
+
             # Log a warning if commit-to-commit comparison was attempted
             if base_commit and target_commit:
                 logger.warning(

--- a/src/difflicious/services/diff_service.py
+++ b/src/difflicious/services/diff_service.py
@@ -22,6 +22,7 @@ class DiffService(BaseService):
         unstaged: bool = True,
         untracked: bool = False,
         file_path: Optional[str] = None,
+        base_ref: Optional[str] = None,
     ) -> dict[str, Any]:
         """Get processed diff data grouped by type.
 
@@ -65,6 +66,7 @@ class DiffService(BaseService):
                 include_unstaged=unstaged,
                 include_untracked=untracked,
                 file_path=file_path,
+                base_ref=base_ref,
             )
 
             # Process each group to parse diff content for rendering

--- a/src/difflicious/services/git_service.py
+++ b/src/difflicious/services/git_service.py
@@ -22,7 +22,7 @@ class GitService(BaseService):
             repo_name = self.repo.get_repository_name()
 
             # Get diff data to count changed files
-            diff_data = self.repo.get_diff(unstaged=True, untracked=True)
+            diff_data = self.repo.get_diff(include_unstaged=True, include_untracked=True)
             total_files = sum(group.get("count", 0) for group in diff_data.values())
 
             return {

--- a/src/difflicious/services/git_service.py
+++ b/src/difflicious/services/git_service.py
@@ -22,7 +22,9 @@ class GitService(BaseService):
             repo_name = self.repo.get_repository_name()
 
             # Get diff data to count changed files
-            diff_data = self.repo.get_diff(include_unstaged=True, include_untracked=True)
+            diff_data = self.repo.get_diff(
+                include_unstaged=True, include_untracked=True
+            )
             total_files = sum(group.get("count", 0) for group in diff_data.values())
 
             return {

--- a/src/difflicious/services/git_service.py
+++ b/src/difflicious/services/git_service.py
@@ -22,7 +22,9 @@ class GitService(BaseService):
             repo_name = self.repo.get_repository_name()
 
             # Use lightweight summary instead of full diff content
-            summary = self.repo.summarize_changes(include_unstaged=True, include_untracked=True)
+            summary = self.repo.summarize_changes(
+                include_unstaged=True, include_untracked=True
+            )
             total_files = sum(group.get("count", 0) for group in summary.values())
 
             return {

--- a/src/difflicious/services/git_service.py
+++ b/src/difflicious/services/git_service.py
@@ -21,11 +21,9 @@ class GitService(BaseService):
             current_branch = self.repo.get_current_branch()
             repo_name = self.repo.get_repository_name()
 
-            # Get diff data to count changed files
-            diff_data = self.repo.get_diff(
-                include_unstaged=True, include_untracked=True
-            )
-            total_files = sum(group.get("count", 0) for group in diff_data.values())
+            # Use lightweight summary instead of full diff content
+            summary = self.repo.summarize_changes(include_unstaged=True, include_untracked=True)
+            total_files = sum(group.get("count", 0) for group in summary.values())
 
             return {
                 "current_branch": current_branch,

--- a/src/difflicious/services/template_service.py
+++ b/src/difflicious/services/template_service.py
@@ -169,7 +169,7 @@ class TemplateRenderingService(BaseService):
             ui_staged = staged
 
             logger.info(
-                f"Template final: base_commit='{base_commit}', current_branch='{current_branch}', is_head_comparison={is_head_comparison}"
+                f"Template final: base_ref='{base_commit}', current_branch='{current_branch}', is_head_comparison={is_head_comparison}"
             )
 
             return {
@@ -181,7 +181,7 @@ class TemplateRenderingService(BaseService):
                 "groups": enhanced_groups,
                 "total_files": total_files,
                 # UI state
-                "current_base_branch": base_commit
+                "current_base_ref": base_commit
                 or branch_info.get("branches", {}).get("default", "main"),
                 "unstaged": ui_unstaged,
                 "staged": ui_staged,

--- a/src/difflicious/services/template_service.py
+++ b/src/difflicious/services/template_service.py
@@ -124,7 +124,9 @@ class TemplateRenderingService(BaseService):
 
             # Determine if we're comparing to HEAD (current branch)
             current_branch = repo_status.get("current_branch", "unknown")
-            is_head_comparison = base_commit in ["HEAD", current_branch]
+            is_head_comparison = base_commit in ["HEAD", current_branch] if base_commit else False
+            
+            logger.info(f"Template final: base_commit='{base_commit}', current_branch='{current_branch}', is_head_comparison={is_head_comparison}")
             
             return {
                 # Repository info
@@ -332,9 +334,11 @@ class TemplateRenderingService(BaseService):
             "total_files": 0,
             "current_base_branch": "main",
             "unstaged": True,
+            "staged": True,
             "untracked": False,
             "search_filter": "",
             "syntax_css": "",
             "loading": False,
             "error": error_message,
+            "is_head_comparison": False,
         }

--- a/src/difflicious/services/template_service.py
+++ b/src/difflicious/services/template_service.py
@@ -369,7 +369,7 @@ class TemplateRenderingService(BaseService):
                 "staged": {"files": [], "count": 0},
             },
             "total_files": 0,
-            "current_base_branch": "main",
+            "current_base_ref": "main",
             "unstaged": True,
             "staged": True,
             "untracked": False,

--- a/src/difflicious/services/template_service.py
+++ b/src/difflicious/services/template_service.py
@@ -54,10 +54,14 @@ class TemplateRenderingService(BaseService):
             # Get diff data with explicit logic for the two main use cases
             # Map base_commit parameter to use_head logic
             current_branch = repo_status.get("current_branch", "unknown")
-            is_head_comparison = base_commit in ["HEAD", current_branch] if base_commit else False
-            
-            logger.info(f"Template service: base_commit='{base_commit}', current_branch='{current_branch}', use_head={is_head_comparison}")
-            
+            is_head_comparison = (
+                base_commit in ["HEAD", current_branch] if base_commit else False
+            )
+
+            logger.info(
+                f"Template service: base_commit='{base_commit}', current_branch='{current_branch}', use_head={is_head_comparison}"
+            )
+
             if base_commit:
                 if is_head_comparison:
                     # Working directory vs HEAD comparison
@@ -69,11 +73,11 @@ class TemplateRenderingService(BaseService):
                         untracked=untracked,
                         file_path=file_path,
                     )
-                    
+
                     # For HEAD comparisons, staged changes are always visible
                     # Files can appear in both groups if they have both staged AND unstaged changes
                     # This is correct behavior - it shows what's ready to commit vs what's still being worked on
-                    
+
                     # Remove unstaged group based on checkbox selection (staged always visible)
                     if not unstaged and "unstaged" in grouped_diffs:
                         del grouped_diffs["unstaged"]
@@ -86,27 +90,27 @@ class TemplateRenderingService(BaseService):
                         untracked=untracked,
                         file_path=file_path,
                     )
-                    
+
                     # For branch comparison, combine unstaged + staged into "changes" group
                     changes_files = []
                     changes_count = 0
-                    
+
                     # Add unstaged files
                     if "unstaged" in grouped_diffs:
                         changes_files.extend(grouped_diffs["unstaged"]["files"])
                         changes_count += grouped_diffs["unstaged"]["count"]
-                    
-                    # Add staged files  
+
+                    # Add staged files
                     if "staged" in grouped_diffs:
                         changes_files.extend(grouped_diffs["staged"]["files"])
                         changes_count += grouped_diffs["staged"]["count"]
-                    
+
                     # Replace unstaged group with combined changes group
                     grouped_diffs["changes"] = {
                         "files": changes_files,
-                        "count": changes_count
+                        "count": changes_count,
                     }
-                    
+
                     # Remove the separate unstaged and staged groups
                     if "unstaged" in grouped_diffs:
                         del grouped_diffs["unstaged"]
@@ -121,27 +125,27 @@ class TemplateRenderingService(BaseService):
                     untracked=untracked,
                     file_path=file_path,
                 )
-                
+
                 # For branch comparison, combine unstaged + staged into "changes" group
                 changes_files = []
                 changes_count = 0
-                
+
                 # Add unstaged files
                 if "unstaged" in grouped_diffs:
                     changes_files.extend(grouped_diffs["unstaged"]["files"])
                     changes_count += grouped_diffs["unstaged"]["count"]
-                
-                # Add staged files  
+
+                # Add staged files
                 if "staged" in grouped_diffs:
                     changes_files.extend(grouped_diffs["staged"]["files"])
                     changes_count += grouped_diffs["staged"]["count"]
-                
+
                 # Replace unstaged group with combined changes group
                 grouped_diffs["changes"] = {
                     "files": changes_files,
-                    "count": changes_count
+                    "count": changes_count,
                 }
-                
+
                 # Remove the separate unstaged and staged groups
                 if "unstaged" in grouped_diffs:
                     del grouped_diffs["unstaged"]
@@ -159,9 +163,11 @@ class TemplateRenderingService(BaseService):
             # Pass through the UI state parameters as received from the user
             ui_unstaged = unstaged
             ui_staged = staged
-            
-            logger.info(f"Template final: base_commit='{base_commit}', current_branch='{current_branch}', is_head_comparison={is_head_comparison}")
-            
+
+            logger.info(
+                f"Template final: base_commit='{base_commit}', current_branch='{current_branch}', is_head_comparison={is_head_comparison}"
+            )
+
             return {
                 # Repository info
                 "repo_status": repo_status,

--- a/src/difflicious/services/template_service.py
+++ b/src/difflicious/services/template_service.py
@@ -31,6 +31,7 @@ class TemplateRenderingService(BaseService):
         file_path: Optional[str] = None,
         search_filter: Optional[str] = None,
         expand_files: bool = False,
+        base_ref: Optional[str] = None,
     ) -> dict[str, Any]:
         """Prepare complete diff data optimized for Jinja2 template rendering.
 
@@ -72,6 +73,7 @@ class TemplateRenderingService(BaseService):
                         unstaged=True,  # Always get unstaged files for HEAD comparisons
                         untracked=untracked,
                         file_path=file_path,
+                        base_ref=None,
                     )
 
                     # For HEAD comparisons, staged changes are always visible
@@ -89,6 +91,7 @@ class TemplateRenderingService(BaseService):
                         unstaged=True,  # Always show changes for branch comparisons
                         untracked=untracked,
                         file_path=file_path,
+                        base_ref=base_ref,
                     )
 
                     # For branch comparison, combine unstaged + staged into "changes" group
@@ -124,6 +127,7 @@ class TemplateRenderingService(BaseService):
                     unstaged=True,  # Always show changes for branch comparisons
                     untracked=untracked,
                     file_path=file_path,
+                    base_ref=base_ref,
                 )
 
                 # For branch comparison, combine unstaged + staged into "changes" group

--- a/src/difflicious/static/js/app.js
+++ b/src/difflicious/static/js/app.js
@@ -383,9 +383,12 @@ function diffliciousApp() { // eslint-disable-line no-unused-vars
                 // Build query parameters based on UI state
                 const params = new URLSearchParams();
 
-                // Handle branch selection
+                // Handle comparison mode selection
                 if (this.baseBranch) {
-                    params.set('base_commit', this.baseBranch);
+                    // Determine comparison mode based on baseBranch
+                    const isHeadComparison = this.baseBranch === 'HEAD' || this.baseBranch === this.branches.current;
+                    params.set('use_head', isHeadComparison.toString());
+                    params.set('base_commit', this.baseBranch); // Keep for compatibility
                 }
 
                 // Handle unstaged/untracked options

--- a/src/difflicious/static/js/app.js
+++ b/src/difflicious/static/js/app.js
@@ -385,10 +385,11 @@ function diffliciousApp() { // eslint-disable-line no-unused-vars
 
                 // Handle comparison mode selection
                 if (this.baseBranch) {
-                    // Determine comparison mode based on baseBranch
+                    // Determine comparison mode based on base_ref
                     const isHeadComparison = this.baseBranch === 'HEAD' || this.baseBranch === this.branches.current;
                     params.set('use_head', isHeadComparison.toString());
-                    params.set('base_commit', this.baseBranch); // Keep for compatibility
+                    params.set('base_ref', this.baseBranch);
+                    params.set('base_commit', this.baseBranch); // legacy compat
                 }
 
                 // Handle unstaged/untracked options

--- a/src/difflicious/static/js/diff-interactions.js
+++ b/src/difflicious/static/js/diff-interactions.js
@@ -22,8 +22,8 @@ const DiffState = {
         const expandAllBtn = $('#expandAll');
         const collapseAllBtn = $('#collapseAll');
 
-        if (expandAllBtn) expandAllBtn.addEventListener('click', () => this.expandAllFiles());
-        if (collapseAllBtn) collapseAllBtn.addEventListener('click', () => this.collapseAllFiles());
+        if (expandAllBtn) expandAllBtn.addEventListener('click', () => expandAllFiles());
+        if (collapseAllBtn) collapseAllBtn.addEventListener('click', () => collapseAllFiles());
 
         // Form auto-submit on changes
         $$('input[type="checkbox"], select').forEach(input => {

--- a/src/difflicious/static/js/diff-interactions.js
+++ b/src/difflicious/static/js/diff-interactions.js
@@ -761,12 +761,12 @@ document.addEventListener('DOMContentLoaded', () => {
         });
 
         // Ensure all expansion buttons are enabled and functional
-        console.log('Initializing expansion buttons...');
+        // console.log('Initializing expansion buttons...');
         $$('.expansion-btn').forEach((button, index) => {
             const targetStart = parseInt(button.dataset.targetStart);
             const targetEnd = parseInt(button.dataset.targetEnd);
 
-            console.log(`Button ${index}: direction=${button.dataset.direction}, targetStart=${targetStart}, targetEnd=${targetEnd}`);
+            // console.log(`Button ${index}: direction=${button.dataset.direction}, targetStart=${targetStart}, targetEnd=${targetEnd}`);
 
             // Ensure button is properly enabled
             button.disabled = false;
@@ -775,7 +775,7 @@ document.addEventListener('DOMContentLoaded', () => {
             button.style.pointerEvents = 'auto';
             button.title = `Expand 10 lines ${button.dataset.direction} (${targetStart}-${targetEnd})`;
 
-            console.log(`Button ${index} enabled and ready`);
+            // console.log(`Button ${index} enabled and ready`);
         });
     }, 100);
 });

--- a/src/difflicious/templates/diff_file.html
+++ b/src/difflicious/templates/diff_file.html
@@ -10,7 +10,11 @@
                 {{ '▼' if file.expanded else '▶' }}
             </span>
             <span class="font-mono text-sm text-gray-900">{{ file.path }}</span>
-            <span class="text-xs text-gray-500 bg-gray-100 px-2 py-1 rounded">
+            <span class="text-xs px-2 py-1 rounded
+                {%- if file.status == 'added' %} bg-green-100 text-green-800
+                {%- elif file.status == 'deleted' %} bg-red-100 text-red-800
+                {%- else %} bg-gray-100 text-gray-500
+                {%- endif %}">
                 {{ file.status }}
             </span>
         </div>

--- a/src/difflicious/templates/diff_file.html
+++ b/src/difflicious/templates/diff_file.html
@@ -1,8 +1,9 @@
 <!-- Single File Diff -->
-<div class="file-diff bg-white border border-gray-200 rounded-lg shadow-sm" data-file="{{ file.path }}">
+{% set file_id = group_name + ":" + file.path %}
+<div class="file-diff bg-white border border-gray-200 rounded-lg shadow-sm" data-file="{{ file_id }}">
     <!-- File Header -->
     <div class="file-header flex items-center justify-between p-4 cursor-pointer hover:bg-gray-50 transition-colors"
-         onclick="toggleFile('{{ file.path }}')">
+         onclick="toggleFile('{{ file_id }}')">
         <div class="flex items-center space-x-3">
             <span class="toggle-icon text-gray-400 transition-transform duration-200"
                 data-expanded="{{ 'true' if file.expanded else 'false' }}">
@@ -17,12 +18,12 @@
         <div class="flex items-center space-x-2 text-xs">
             <!-- File Navigation -->
             <div class="flex items-center space-x-1" onclick="event.stopPropagation()">
-                <button onclick="navigateToPreviousFile('{{ file.path }}')"
+                <button onclick="navigateToPreviousFile('{{ file_id }}')"
                     class="p-1 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded transition-colors"
                     title="Previous file">
                     <span class="text-sm">↑</span>
                 </button>
-                <button onclick="navigateToNextFile('{{ file.path }}')"
+                <button onclick="navigateToNextFile('{{ file_id }}')"
                     class="p-1 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded transition-colors"
                     title="Next file">
                     <span class="text-sm">↓</span>
@@ -44,7 +45,7 @@
     </div>
 
     <!-- File Content -->
-    <div class="file-content border-t border-gray-200" data-file-content="{{ file.path }}"
+    <div class="file-content border-t border-gray-200" data-file-content="{{ file_id }}"
         style="display: {{ 'block' if file.expanded else 'none' }};">
         {% if not file.hunks or file.hunks|length == 0 %}
         <!-- No content available -->

--- a/src/difflicious/templates/diff_groups.html
+++ b/src/difflicious/templates/diff_groups.html
@@ -20,7 +20,8 @@
     <div class="group-content space-y-4 {% if not hide_header %}ml-4{% endif %}" 
          data-group-content="{{ group_key }}">
         {% for file in group.files %}
-        {% include "diff_file.html" %}
+        {% set group_name = group_key %}
+        {% include "diff_file.html" with context %}
         {% endfor %}
     </div>
 </div>

--- a/src/difflicious/templates/index.html
+++ b/src/difflicious/templates/index.html
@@ -1,24 +1,26 @@
 {% extends "base.html" %}
 
 {% block content %}
-{{ render_partial('partials/toolbar.html', 
-   branches=branches, 
-   current_base_branch=current_base_branch, 
-   unstaged=unstaged, 
-   untracked=untracked, 
-   search_filter=search_filter, 
-   total_files=total_files) }}
+{{ render_partial('partials/toolbar.html',
+branches=branches,
+current_base_branch=current_base_branch,
+unstaged=unstaged,
+staged=staged,
+untracked=untracked,
+search_filter=search_filter,
+total_files=total_files,
+is_head_comparison=is_head_comparison) }}
 
 <!-- Main Content -->
 <main class="flex-1 overflow-hidden">
     {% if loading %}
     {{ render_partial('partials/loading_state.html') }}
     {% elif not groups or not total_files %}
-    {{ render_partial('partials/empty_state.html', 
-       error=error, 
-       unstaged=unstaged, 
-       untracked=untracked, 
-       current_base_branch=current_base_branch) }}
+    {{ render_partial('partials/empty_state.html',
+    error=error,
+    unstaged=unstaged,
+    untracked=untracked,
+    current_base_branch=current_base_branch) }}
     {% else %}
     <!-- Diff Content -->
     <div class="h-full overflow-y-auto">

--- a/src/difflicious/templates/index.html
+++ b/src/difflicious/templates/index.html
@@ -3,7 +3,7 @@
 {% block content %}
 {{ render_partial('partials/toolbar.html',
 branches=branches,
-current_base_branch=current_base_branch,
+current_base_ref=current_base_ref,
 unstaged=unstaged,
 staged=staged,
 untracked=untracked,
@@ -20,7 +20,7 @@ is_head_comparison=is_head_comparison) }}
     error=error,
     unstaged=unstaged,
     untracked=untracked,
-    current_base_branch=current_base_branch) }}
+    current_base_ref=current_base_ref) }}
     {% else %}
     <!-- Diff Content -->
     <div class="h-full overflow-y-auto">

--- a/src/difflicious/templates/partials/empty_state.html
+++ b/src/difflicious/templates/partials/empty_state.html
@@ -19,9 +19,9 @@
             {% else %}
             <p>Your working directory is clean - no unstaged or untracked files.</p>
             {% endif %}
-            {% if current_base_branch != 'main' %}
+            {% if current_base_ref != 'main' %}
             <p class="text-sm text-gray-500 mt-3">
-                Comparing against branch: <span class="font-mono">{{ current_base_branch }}</span>
+                Comparing against: <span class="font-mono">{{ current_base_ref }}</span>
             </p>
             {% endif %}
         </div>

--- a/src/difflicious/templates/partials/toolbar.html
+++ b/src/difflicious/templates/partials/toolbar.html
@@ -18,6 +18,7 @@
 
                 <!-- Diff Options -->
                 <div class="flex items-center space-x-4">
+                    <!-- DEBUG: is_head_comparison = {{ is_head_comparison }}, base_commit = {{ current_base_branch }} -->
                     {% if is_head_comparison %}
                     <!-- HEAD comparison: only show "Changes" and "Untracked" -->
                     <label class="flex items-center">

--- a/src/difflicious/templates/partials/toolbar.html
+++ b/src/difflicious/templates/partials/toolbar.html
@@ -20,40 +20,29 @@
                 <div class="flex items-center space-x-4">
                     <!-- DEBUG: is_head_comparison = {{ is_head_comparison }}, base_commit = {{ current_base_branch }} -->
                     {% if is_head_comparison %}
-                    <!-- HEAD comparison: only show "Changes" and "Untracked" -->
+                    <!-- HEAD comparison: show "Unstaged" and "Untracked" -->
                     <label class="flex items-center">
                         <input type="checkbox" name="unstaged" value="true" {% if unstaged %}checked{% endif %}
-                            onchange="this.form.submit()"
-                            class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded">
+                            class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded checkbox-control">
+                        <span class="ml-1 text-sm text-gray-700">Unstaged</span>
+                    </label>
+
+                    <label class="flex items-center">
+                        <input type="checkbox" name="untracked" value="true" {% if untracked %}checked{% endif %}
+                            class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded checkbox-control">
+                        <span class="ml-1 text-sm text-gray-700">Untracked</span>
+                    </label>
+                    {% else %}
+                    <!-- Branch comparison: show "Changes" and "Untracked" -->
+                    <label class="flex items-center">
+                        <input type="checkbox" name="unstaged" value="true" {% if unstaged %}checked{% endif %}
+                            class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded checkbox-control">
                         <span class="ml-1 text-sm text-gray-700">Changes</span>
                     </label>
 
                     <label class="flex items-center">
                         <input type="checkbox" name="untracked" value="true" {% if untracked %}checked{% endif %}
-                            onchange="this.form.submit()"
-                            class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded">
-                        <span class="ml-1 text-sm text-gray-700">Untracked</span>
-                    </label>
-                    {% else %}
-                    <!-- Branch comparison: show "Unstaged", "Staged", and "Untracked" -->
-                    <label class="flex items-center">
-                        <input type="checkbox" name="unstaged" value="true" {% if unstaged %}checked{% endif %}
-                            onchange="this.form.submit()"
-                            class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded">
-                        <span class="ml-1 text-sm text-gray-700">Unstaged</span>
-                    </label>
-
-                    <label class="flex items-center">
-                        <input type="checkbox" name="staged" value="true" {% if staged %}checked{% endif %}
-                            onchange="this.form.submit()"
-                            class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded">
-                        <span class="ml-1 text-sm text-gray-700">Staged</span>
-                    </label>
-
-                    <label class="flex items-center">
-                        <input type="checkbox" name="untracked" value="true" {% if untracked %}checked{% endif %}
-                            onchange="this.form.submit()"
-                            class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded">
+                            class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded checkbox-control">
                         <span class="ml-1 text-sm text-gray-700">Untracked</span>
                     </label>
                     {% endif %}
@@ -77,3 +66,48 @@
         </div>
     </div>
 </header>
+
+<script>
+function updateCheckboxAndSubmit(checkbox) {
+    const form = checkbox.form;
+    const formData = new FormData(form);
+    const params = new URLSearchParams();
+    
+    // Get all form data except checkboxes (we'll handle those explicitly)
+    for (const [key, value] of formData.entries()) {
+        if (key !== 'unstaged' && key !== 'untracked') {
+            params.set(key, value);
+        }
+    }
+    
+    // Explicitly set checkbox states based on their current checked state
+    const unstagedCheckbox = form.querySelector('input[name="unstaged"]');
+    const untrackedCheckbox = form.querySelector('input[name="untracked"]');
+    
+    if (unstagedCheckbox) {
+        params.set('unstaged', unstagedCheckbox.checked ? 'true' : 'false');
+    }
+    if (untrackedCheckbox) {
+        params.set('untracked', untrackedCheckbox.checked ? 'true' : 'false');
+    }
+    
+    // Navigate to the updated URL
+    window.location.href = '?' + params.toString();
+}
+
+// Set up event listeners when DOM is ready
+document.addEventListener('DOMContentLoaded', function() {
+    const checkboxes = document.querySelectorAll('.checkbox-control');
+    
+    checkboxes.forEach(function(checkbox) {
+        checkbox.addEventListener('change', function(event) {
+            // Prevent the default form submission behavior
+            event.preventDefault();
+            event.stopPropagation();
+            event.stopImmediatePropagation();
+            
+            updateCheckboxAndSubmit(this);
+        });
+    });
+});
+</script>

--- a/src/difflicious/templates/partials/toolbar.html
+++ b/src/difflicious/templates/partials/toolbar.html
@@ -7,10 +7,10 @@
             <!-- Base Branch Dropdown -->
             <form method="GET" action="/" class="flex items-center space-x-2">
                 <label class="text-sm font-medium text-gray-700">Base:</label>
-                <select name="base_branch" onchange="this.form.submit()"
+                <select name="base_ref" onchange="this.form.submit()"
                     class="bg-white border border-gray-300 rounded-md px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
                     {% for branch in branches.all %}
-                    <option value="{{ branch }}" {% if branch==current_base_branch %}selected{% endif %}>
+                    <option value="{{ branch }}" {% if branch==current_base_ref %}selected{% endif %}>
                         {{ branch }}
                     </option>
                     {% endfor %}
@@ -18,7 +18,7 @@
 
                 <!-- Diff Options -->
                 <div class="flex items-center space-x-4">
-                    <!-- DEBUG: is_head_comparison = {{ is_head_comparison }}, base_commit = {{ current_base_branch }} -->
+                    <!-- DEBUG: is_head_comparison = {{ is_head_comparison }}, base_ref = {{ current_base_ref }} -->
                     {% if is_head_comparison %}
                     <!-- HEAD comparison: show "Unstaged" and "Untracked" (staged always visible) -->
                     <label class="flex items-center">

--- a/src/difflicious/templates/partials/toolbar.html
+++ b/src/difflicious/templates/partials/toolbar.html
@@ -20,7 +20,7 @@
                 <div class="flex items-center space-x-4">
                     <!-- DEBUG: is_head_comparison = {{ is_head_comparison }}, base_commit = {{ current_base_branch }} -->
                     {% if is_head_comparison %}
-                    <!-- HEAD comparison: show "Unstaged" and "Untracked" -->
+                    <!-- HEAD comparison: show "Unstaged" and "Untracked" (staged always visible) -->
                     <label class="flex items-center">
                         <input type="checkbox" name="unstaged" value="true" {% if unstaged %}checked{% endif %}
                             class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded checkbox-control">
@@ -33,13 +33,7 @@
                         <span class="ml-1 text-sm text-gray-700">Untracked</span>
                     </label>
                     {% else %}
-                    <!-- Branch comparison: show "Changes" and "Untracked" -->
-                    <label class="flex items-center">
-                        <input type="checkbox" name="unstaged" value="true" {% if unstaged %}checked{% endif %}
-                            class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded checkbox-control">
-                        <span class="ml-1 text-sm text-gray-700">Changes</span>
-                    </label>
-
+                    <!-- Branch comparison: only show "Untracked" (changes are always visible) -->
                     <label class="flex items-center">
                         <input type="checkbox" name="untracked" value="true" {% if untracked %}checked{% endif %}
                             class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded checkbox-control">
@@ -75,17 +69,22 @@ function updateCheckboxAndSubmit(checkbox) {
     
     // Get all form data except checkboxes (we'll handle those explicitly)
     for (const [key, value] of formData.entries()) {
-        if (key !== 'unstaged' && key !== 'untracked') {
+        if (key !== 'unstaged' && key !== 'staged' && key !== 'untracked') {
             params.set(key, value);
         }
     }
     
     // Explicitly set checkbox states based on their current checked state
     const unstagedCheckbox = form.querySelector('input[name="unstaged"]');
+    const stagedCheckbox = form.querySelector('input[name="staged"]');
     const untrackedCheckbox = form.querySelector('input[name="untracked"]');
     
     if (unstagedCheckbox) {
         params.set('unstaged', unstagedCheckbox.checked ? 'true' : 'false');
+    }
+    if (stagedCheckbox) {
+        // Only set staged parameter if staged checkbox exists (not in HEAD comparisons)
+        params.set('staged', stagedCheckbox.checked ? 'true' : 'false');
     }
     if (untrackedCheckbox) {
         params.set('untracked', untrackedCheckbox.checked ? 'true' : 'false');

--- a/src/difflicious/templates/partials/toolbar.html
+++ b/src/difflicious/templates/partials/toolbar.html
@@ -10,7 +10,7 @@
                 <select name="base_branch" onchange="this.form.submit()"
                     class="bg-white border border-gray-300 rounded-md px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
                     {% for branch in branches.all %}
-                    <option value="{{ branch }}" {% if branch == current_base_branch %}selected{% endif %}>
+                    <option value="{{ branch }}" {% if branch==current_base_branch %}selected{% endif %}>
                         {{ branch }}
                     </option>
                     {% endfor %}
@@ -18,27 +18,49 @@
 
                 <!-- Diff Options -->
                 <div class="flex items-center space-x-4">
+                    {% if is_head_comparison %}
+                    <!-- HEAD comparison: only show "Changes" and "Untracked" -->
                     <label class="flex items-center">
-                        <input type="checkbox" name="unstaged" value="true" 
-                               {% if unstaged %}checked{% endif %}
-                               onchange="this.form.submit()"
-                               class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded">
-                        <span class="ml-1 text-sm text-gray-700">Unstaged</span>
+                        <input type="checkbox" name="unstaged" value="true" {% if unstaged %}checked{% endif %}
+                            onchange="this.form.submit()"
+                            class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded">
+                        <span class="ml-1 text-sm text-gray-700">Changes</span>
                     </label>
-                    
+
                     <label class="flex items-center">
-                        <input type="checkbox" name="untracked" value="true"
-                               {% if untracked %}checked{% endif %}
-                               onchange="this.form.submit()"
-                               class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded">
+                        <input type="checkbox" name="untracked" value="true" {% if untracked %}checked{% endif %}
+                            onchange="this.form.submit()"
+                            class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded">
                         <span class="ml-1 text-sm text-gray-700">Untracked</span>
                     </label>
+                    {% else %}
+                    <!-- Branch comparison: show "Unstaged", "Staged", and "Untracked" -->
+                    <label class="flex items-center">
+                        <input type="checkbox" name="unstaged" value="true" {% if unstaged %}checked{% endif %}
+                            onchange="this.form.submit()"
+                            class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded">
+                        <span class="ml-1 text-sm text-gray-700">Unstaged</span>
+                    </label>
+
+                    <label class="flex items-center">
+                        <input type="checkbox" name="staged" value="true" {% if staged %}checked{% endif %}
+                            onchange="this.form.submit()"
+                            class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded">
+                        <span class="ml-1 text-sm text-gray-700">Staged</span>
+                    </label>
+
+                    <label class="flex items-center">
+                        <input type="checkbox" name="untracked" value="true" {% if untracked %}checked{% endif %}
+                            onchange="this.form.submit()"
+                            class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded">
+                        <span class="ml-1 text-sm text-gray-700">Untracked</span>
+                    </label>
+                    {% endif %}
                 </div>
-                
+
                 <!-- Search Filter -->
-                <input type="text" name="search" value="{{ search_filter or '' }}" 
-                       placeholder="Search files..." 
-                       class="border border-gray-300 rounded-md px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                <input type="text" name="search" value="{{ search_filter or '' }}" placeholder="Search files..."
+                    class="border border-gray-300 rounded-md px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
             </form>
         </div>
 
@@ -47,7 +69,7 @@
             <div class="text-sm text-gray-600">
                 {{ total_files }} files changed
             </div>
-            <button onclick="location.reload()" 
+            <button onclick="location.reload()"
                 class="bg-blue-600 text-white px-3 py-1.5 rounded-md text-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500">
                 Refresh
             </button>

--- a/test_staging_bug.txt
+++ b/test_staging_bug.txt
@@ -1,0 +1,1 @@
+Test change

--- a/tests/services/test_diff_service.py
+++ b/tests/services/test_diff_service.py
@@ -45,6 +45,26 @@ class TestDiffService:
         mock_repo.get_diff.assert_called_once()
 
     @patch("difflicious.services.base_service.get_git_repository")
+    def test_get_grouped_diffs_with_base_ref(self, mock_get_repo):
+        """Ensure base_ref gets passed through to the repository layer."""
+        mock_repo = Mock()
+        mock_get_repo.return_value = mock_repo
+        mock_repo.get_diff.return_value = {
+            "unstaged": {"files": [], "count": 0},
+            "staged": {"files": [], "count": 0},
+            "untracked": {"files": [], "count": 0},
+        }
+
+        base_ref = "feature-x"
+        service = DiffService()
+        service.get_grouped_diffs(unstaged=True, base_ref=base_ref)
+
+        # Verify base_ref was passed through
+        assert mock_repo.get_diff.called
+        _, kwargs = mock_repo.get_diff.call_args
+        assert kwargs.get("base_ref") == base_ref
+
+    @patch("difflicious.services.base_service.get_git_repository")
     def test_get_grouped_diffs_git_error(self, mock_get_repo):
         """Test diff service error handling for git operation errors."""
         # Setup mocks

--- a/tests/services/test_git_service.py
+++ b/tests/services/test_git_service.py
@@ -21,7 +21,7 @@ class TestGitService:
         mock_get_repo.return_value = mock_repo
         mock_repo.get_current_branch.return_value = "main"
         mock_repo.get_repository_name.return_value = "test-repo"
-        mock_repo.get_diff.return_value = {
+        mock_repo.summarize_changes.return_value = {
             "unstaged": {"count": 2},
             "staged": {"count": 1},
             "untracked": {"count": 0},

--- a/tests/services/test_template_service.py
+++ b/tests/services/test_template_service.py
@@ -104,6 +104,35 @@ class TestTemplateRenderingService:
     @patch("difflicious.services.template_service.DiffService")
     @patch("difflicious.services.template_service.GitService")
     @patch("difflicious.services.template_service.SyntaxHighlightingService")
+    def test_prepare_diff_data_for_template_with_base_ref(
+        self, mock_syntax_service, mock_git_service, mock_diff_service
+    ):
+        """Ensure base_ref is threaded through to DiffService."""
+        mock_diff_instance = mock_diff_service.return_value
+        mock_git_instance = mock_git_service.return_value
+        mock_syntax_service.return_value.get_css_styles.return_value = ""
+
+        mock_git_instance.get_repository_status.return_value = {
+            "current_branch": "main"
+        }
+        mock_git_instance.get_branch_information.return_value = {
+            "branches": {"all": ["main"], "default": "main"}
+        }
+        mock_diff_instance.get_grouped_diffs.return_value = {
+            "unstaged": {"files": [], "count": 0},
+            "staged": {"files": [], "count": 0},
+        }
+
+        service = TemplateRenderingService()
+        service.prepare_diff_data_for_template(base_ref="feature-x")
+
+        assert mock_diff_instance.get_grouped_diffs.called
+        _, kwargs = mock_diff_instance.get_grouped_diffs.call_args
+        assert kwargs.get("base_ref") == "feature-x"
+
+    @patch("difflicious.services.template_service.DiffService")
+    @patch("difflicious.services.template_service.GitService")
+    @patch("difflicious.services.template_service.SyntaxHighlightingService")
     def test_prepare_diff_data_for_template_with_search_filter(
         self, mock_syntax_service, mock_git_service, mock_diff_service
     ):

--- a/tests/services/test_template_service.py
+++ b/tests/services/test_template_service.py
@@ -160,8 +160,9 @@ class TestTemplateRenderingService:
         result = service.prepare_diff_data_for_template(search_filter="test")
 
         # Should only include files matching "test"
-        assert result["groups"]["unstaged"]["count"] == 1
-        assert result["groups"]["unstaged"]["files"][0]["path"] == "test.py"
+        # When no base_commit is provided, unstaged and staged are combined into "changes"
+        assert result["groups"]["changes"]["count"] == 1
+        assert result["groups"]["changes"]["files"][0]["path"] == "test.py"
 
     def test_process_line_side_with_content(self):
         """Test processing line side with content."""

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -78,6 +78,17 @@ def test_api_diff_route(client):
     assert "staged" in data["groups"]
 
 
+def test_api_diff_route_with_base_ref(client):
+    """Test that the API diff endpoint accepts base_ref and forwards it."""
+    response = client.get("/api/diff?base_ref=feature-x")
+    assert response.status_code == 200
+    assert response.is_json
+
+    data = response.get_json()
+    assert data["status"] == "ok"
+    assert data.get("base_ref") == "feature-x"
+
+
 class TestAPIDiffCommitComparison:
     """Test cases for API diff endpoint commit comparison functionality."""
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -118,7 +118,9 @@ class TestAPIDiffCommitComparison:
 
     def test_api_diff_with_base_ref_and_other_params(self, client):
         """Test API diff endpoint with base_ref and other parameters."""
-        response = client.get("/api/diff?base_ref=abc123&unstaged=true&untracked=false&file=test.txt")
+        response = client.get(
+            "/api/diff?base_ref=abc123&unstaged=true&untracked=false&file=test.txt"
+        )
         assert response.status_code == 200
         assert response.is_json
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -90,65 +90,41 @@ def test_api_diff_route_with_base_ref(client):
 
 
 class TestAPIDiffCommitComparison:
-    """Test cases for API diff endpoint commit comparison functionality."""
+    """Test cases for API diff endpoint base_ref functionality."""
 
-    def test_api_diff_with_base_commit_parameter(self, client):
-        """Test API diff endpoint with base_commit parameter."""
-        response = client.get("/api/diff?base_commit=abc123")
+    def test_api_diff_with_base_ref_parameter(self, client):
+        """Test API diff endpoint with base_ref parameter."""
+        response = client.get("/api/diff?base_ref=abc123")
         assert response.status_code == 200
         assert response.is_json
 
         data = response.get_json()
         assert data["status"] == "ok"
-        assert data["base_commit"] == "abc123"
-        assert data["target_commit"] is None
+        assert data["base_ref"] == "abc123"
         assert "groups" in data
         assert isinstance(data["groups"], dict)
 
-    def test_api_diff_with_target_commit_parameter(self, client):
-        """Test API diff endpoint with target_commit parameter."""
+    def test_api_diff_ignores_target_commit_parameter(self, client):
+        """Target commit is ignored; API still returns ok and includes base_ref when set."""
         response = client.get("/api/diff?target_commit=def456")
         assert response.status_code == 200
         assert response.is_json
 
         data = response.get_json()
         assert data["status"] == "ok"
-        assert data["base_commit"] is None
-        assert data["target_commit"] == "def456"
+        assert "base_ref" in data
         assert "groups" in data
         assert isinstance(data["groups"], dict)
 
-    def test_api_diff_with_both_commits(self, client):
-        """Test API diff endpoint with both commit parameters."""
-        response = client.get("/api/diff?base_commit=abc123&target_commit=def456")
+    def test_api_diff_with_base_ref_and_other_params(self, client):
+        """Test API diff endpoint with base_ref and other parameters."""
+        response = client.get("/api/diff?base_ref=abc123&unstaged=true&untracked=false&file=test.txt")
         assert response.status_code == 200
         assert response.is_json
 
         data = response.get_json()
         assert data["status"] == "ok"
-        assert data["base_commit"] == "abc123"
-        assert data["target_commit"] == "def456"
-        assert "groups" in data
-        assert isinstance(data["groups"], dict)
-
-    def test_api_diff_with_all_parameters(self, client):
-        """Test API diff endpoint with all parameters combined."""
-        params = {
-            "base_commit": "abc123",
-            "target_commit": "def456",
-            "unstaged": "true",
-            "untracked": "false",
-            "file": "test.txt",
-        }
-
-        response = client.get("/api/diff", query_string=params)
-        assert response.status_code == 200
-        assert response.is_json
-
-        data = response.get_json()
-        assert data["status"] == "ok"
-        assert data["base_commit"] == "abc123"
-        assert data["target_commit"] == "def456"
+        assert data["base_ref"] == "abc123"
         assert data["unstaged"] is True
         assert data["untracked"] is False
         assert data["file_filter"] == "test.txt"
@@ -167,40 +143,37 @@ class TestAPIDiffCommitComparison:
         assert data["unstaged"] is True
         assert data["untracked"] is False
         assert data["file_filter"] == "test.txt"
-        assert data["base_commit"] is None
-        assert data["target_commit"] is None
+        assert "base_ref" in data
         assert "groups" in data
         assert isinstance(data["groups"], dict)
 
-    def test_api_diff_empty_commit_parameters(self, client):
-        """Test API diff endpoint with empty commit parameters."""
-        response = client.get("/api/diff?base_commit=&target_commit=")
+    def test_api_diff_empty_base_ref_parameter(self, client):
+        """Test API diff endpoint with empty base_ref parameter."""
+        response = client.get("/api/diff?base_ref=")
         assert response.status_code == 200
         assert response.is_json
 
         data = response.get_json()
         assert data["status"] == "ok"
-        assert data["base_commit"] == ""
-        assert data["target_commit"] == ""
+        assert data.get("base_ref") == ""
         assert "groups" in data
         assert isinstance(data["groups"], dict)
 
     def test_api_diff_commit_parameters_with_special_characters(self, client):
-        """Test API diff endpoint handles commit parameters with various characters."""
+        """Test API diff endpoint handles base_ref with various characters."""
         # Test with branch name containing slashes
-        response = client.get("/api/diff?base_commit=feature/new-ui")
+        response = client.get("/api/diff?base_ref=feature/new-ui")
         assert response.status_code == 200
 
         data = response.get_json()
-        assert data["base_commit"] == "feature/new-ui"
+        assert data["base_ref"] == "feature/new-ui"
 
         # Test with HEAD references
-        response = client.get("/api/diff?base_commit=HEAD~1&target_commit=HEAD")
+        response = client.get("/api/diff?base_ref=HEAD~1")
         assert response.status_code == 200
 
         data = response.get_json()
-        assert data["base_commit"] == "HEAD~1"
-        assert data["target_commit"] == "HEAD"
+        assert data["base_ref"] == "HEAD~1"
 
     def test_api_diff_response_format_consistency(self, client):
         """Test API diff endpoint response format is consistent."""
@@ -225,8 +198,6 @@ class TestAPIDiffCommitComparison:
             assert field in data1
             assert field in data2
 
-        # Commit-specific fields should be present in both
-        commit_fields = ["base_commit", "target_commit"]
-        for field in commit_fields:
-            assert field in data1
-            assert field in data2
+        # base_ref should be present in both
+        assert "base_ref" in data1
+        assert "base_ref" in data2

--- a/tests/test_git_operations.py
+++ b/tests/test_git_operations.py
@@ -348,104 +348,109 @@ class TestGitRepositoryCommitComparison:
         assert not repo._is_safe_commit_sha("a" * 101)  # Too long
 
     @patch("difflicious.git_operations.GitRepository._execute_git_command")
-    def test_get_diff_with_commit_comparison(self, mock_execute, mock_git_repo):
-        """Test get_diff with commit comparison parameters."""
+    @patch("difflicious.git_operations.GitRepository.get_branches")
+    def test_get_diff_with_default_branch_comparison(self, mock_get_branches, mock_execute, mock_git_repo):
+        """Test get_diff with default branch comparison."""
         repo = GitRepository(str(mock_git_repo))
 
-        # Mock git rev-parse for SHA validation
+        # Mock get_branches to return main as default
+        mock_get_branches.return_value = {"default_branch": "main", "branches": ["main"]}
+
+        # Mock git rev-parse for SHA validation and diff
         def mock_git_response(args):
             if "rev-parse" in args:
-                return "abc123def456", "", 0
+                return "main_sha", "", 0
             elif "diff" in args:
                 return "5\t2\ttest.txt\n", "", 0
             return "", "", 1
 
         mock_execute.side_effect = mock_git_response
 
-        # Test base_commit + target_commit
-        diffs = repo.get_diff(base_commit="abc123", target_commit="def456")
+        # Test default behavior (compare to default branch)
+        diffs = repo.get_diff(include_unstaged=True)
         assert isinstance(diffs, dict)
         assert "untracked" in diffs
         assert "unstaged" in diffs
         assert "staged" in diffs
 
-        # Verify correct git command was called
-        diff_calls = [
-            call for call in mock_execute.call_args_list if "diff" in call[0][0]
-        ]
-        assert len(diff_calls) > 0
-        diff_args = diff_calls[0][0][0]
-        assert "abc123" in diff_args
-        assert "def456" in diff_args
-
-    @patch("difflicious.git_operations.GitRepository._execute_git_command")
-    def test_get_diff_with_base_commit_only(self, mock_execute, mock_git_repo):
-        """Test get_diff with only base commit (compare to working directory)."""
-        repo = GitRepository(str(mock_git_repo))
-
-        # Mock git rev-parse for SHA validation
-        def mock_git_response(args):
-            if "rev-parse" in args:
-                return "abc123def456", "", 0
-            elif "diff" in args:
-                return "3\t1\tfile.txt\n", "", 0
-            return "", "", 1
-
-        mock_execute.side_effect = mock_git_response
-
-        # Test base_commit only
-        diffs = repo.get_diff(base_commit="abc123")
-        assert isinstance(diffs, dict)
-        assert "untracked" in diffs
-        assert "unstaged" in diffs
-        assert "staged" in diffs
-
-        # Verify correct git command was called
-        diff_calls = [
-            call for call in mock_execute.call_args_list if "diff" in call[0][0]
-        ]
-        assert len(diff_calls) > 0
-        diff_args = diff_calls[0][0][0]
-        assert "abc123" in diff_args
-
-    @patch("difflicious.git_operations.GitRepository._execute_git_command")
-    def test_get_diff_default_to_main_branch(self, mock_execute, mock_git_repo):
-        """Test get_diff defaults to main branch when target_commit specified."""
-        repo = GitRepository(str(mock_git_repo))
-
-        # Mock git rev-parse for SHA validation
-        def mock_git_response(args):
-            if "rev-parse" in args:
-                if "main" in args:
-                    return "main_sha", "", 0
-                else:
-                    return "target_sha", "", 0
-            elif "diff" in args:
-                return "2\t3\ttest.txt\n", "", 0
-            return "", "", 1
-
-        mock_execute.side_effect = mock_git_response
-
-        # Test target_commit only (should default base to main)
-        diffs = repo.get_diff(target_commit="def456")
-        assert isinstance(diffs, dict)
-        assert "untracked" in diffs
-        assert "unstaged" in diffs
-        assert "staged" in diffs
-
-        # Verify main branch was used as base
+        # Verify correct git command was called with main branch
         diff_calls = [
             call for call in mock_execute.call_args_list if "diff" in call[0][0]
         ]
         assert len(diff_calls) > 0
         diff_args = diff_calls[0][0][0]
         assert "main" in diff_args
-        assert "def456" in diff_args
 
     @patch("difflicious.git_operations.GitRepository._execute_git_command")
-    def test_get_diff_fallback_to_head(self, mock_execute, mock_git_repo):
-        """Test get_diff falls back to HEAD when main doesn't exist."""
+    def test_get_diff_with_head_comparison(self, mock_execute, mock_git_repo):
+        """Test get_diff with HEAD comparison."""
         repo = GitRepository(str(mock_git_repo))
+
+        # Mock git rev-parse for SHA validation
+        def mock_git_response(args):
+            if "rev-parse" in args:
+                return "head_sha", "", 0
+            elif "diff" in args:
+                return "3\t1\tfile.txt\n", "", 0
+            return "", "", 1
+
+        mock_execute.side_effect = mock_git_response
+
+        # Test HEAD comparison
+        diffs = repo.get_diff(use_head=True, include_unstaged=True)
+        assert isinstance(diffs, dict)
+        assert "untracked" in diffs
+        assert "unstaged" in diffs
+        assert "staged" in diffs
+
+        # Verify correct git command was called with HEAD
+        diff_calls = [
+            call for call in mock_execute.call_args_list if "diff" in call[0][0]
+        ]
+        assert len(diff_calls) > 0
+        diff_args = diff_calls[0][0][0]
+        assert "HEAD" in diff_args
+
+    @patch("difflicious.git_operations.GitRepository._execute_git_command")
+    @patch("difflicious.git_operations.GitRepository.get_branches")
+    def test_get_diff_untracked_files(self, mock_get_branches, mock_execute, mock_git_repo):
+        """Test get_diff includes untracked files when requested."""
+        repo = GitRepository(str(mock_git_repo))
+
+        # Mock get_branches to return main as default
+        mock_get_branches.return_value = {"default_branch": "main", "branches": ["main"]}
+
+        # Mock git responses
+        def mock_git_response(args):
+            if "rev-parse" in args:
+                return "main_sha", "", 0
+            elif "status" in args and "--porcelain" in args:
+                return "?? untracked.txt\n", "", 0
+            elif "diff" in args:
+                return "2\t3\ttest.txt\n", "", 0
+            return "", "", 1
+
+        mock_execute.side_effect = mock_git_response
+
+        # Test with untracked files included
+        diffs = repo.get_diff(include_untracked=True, include_unstaged=True)
+        assert isinstance(diffs, dict)
+        assert "untracked" in diffs
+        assert "unstaged" in diffs
+        assert "staged" in diffs
+
+        # Verify untracked files are detected
+        assert diffs["untracked"]["count"] == 1
+        assert diffs["untracked"]["files"][0]["path"] == "untracked.txt"
+
+    @patch("difflicious.git_operations.GitRepository._execute_git_command")
+    @patch("difflicious.git_operations.GitRepository.get_branches")
+    def test_get_diff_fallback_to_head(self, mock_get_branches, mock_execute, mock_git_repo):
+        """Test get_diff falls back to HEAD when default branch doesn't exist."""
+        repo = GitRepository(str(mock_git_repo))
+
+        # Mock get_branches to return main as default, but main doesn't actually exist
+        mock_get_branches.return_value = {"default_branch": "main", "branches": ["main"]}
 
         # Mock git rev-parse responses
         def mock_git_response(args):
@@ -454,16 +459,14 @@ class TestGitRepositoryCommitComparison:
                     return "", "fatal: bad revision", 1  # main doesn't exist
                 elif "HEAD" in args:
                     return "head_sha", "", 0
-                else:
-                    return "target_sha", "", 0
             elif "diff" in args:
                 return "1\t1\tfile.txt\n", "", 0
             return "", "", 1
 
         mock_execute.side_effect = mock_git_response
 
-        # Test target_commit only with main not existing
-        diffs = repo.get_diff(target_commit="def456")
+        # Test default behavior when main doesn't exist (should fallback to HEAD)
+        diffs = repo.get_diff(include_unstaged=True)
         assert isinstance(diffs, dict)
         assert "untracked" in diffs
         assert "unstaged" in diffs
@@ -476,25 +479,21 @@ class TestGitRepositoryCommitComparison:
         assert len(diff_calls) > 0
         diff_args = diff_calls[0][0][0]
         assert "HEAD" in diff_args
-        assert "def456" in diff_args
 
-    def test_get_diff_invalid_base_commit(self, mock_git_repo):
-        """Test get_diff with invalid base commit."""
+    def test_get_diff_with_file_path_filter(self, mock_git_repo):
+        """Test get_diff with specific file path filter."""
         repo = GitRepository(str(mock_git_repo))
 
-        # Should return empty groups due to error handling, not raise exception
-        result = repo.get_diff(base_commit="HEAD; rm -rf /")
-        assert isinstance(result, dict)
-        assert all(group["count"] == 0 for group in result.values())
+        # Create a test file for filtering
+        test_file = mock_git_repo / "specific_file.txt"
+        test_file.write_text("test content")
 
-    def test_get_diff_invalid_target_commit(self, mock_git_repo):
-        """Test get_diff with invalid target commit."""
-        repo = GitRepository(str(mock_git_repo))
-
-        # Should return empty groups due to error handling, not raise exception
-        result = repo.get_diff(base_commit="HEAD", target_commit="HEAD | cat")
+        # Test with file path filter
+        result = repo.get_diff(file_path="specific_file.txt", include_unstaged=True)
         assert isinstance(result, dict)
-        assert all(group["count"] == 0 for group in result.values())
+        assert "untracked" in result
+        assert "unstaged" in result
+        assert "staged" in result
 
     @patch("difflicious.git_operations.GitRepository._execute_git_command")
     def test_get_file_diff_with_commits(self, mock_execute, mock_git_repo):
@@ -544,15 +543,15 @@ class TestGitRepositoryCommitComparison:
         test_file.write_text("Modified content\n")
 
         # Test traditional usage still works
-        diffs = repo.get_diff(unstaged=True)
+        diffs = repo.get_diff(include_unstaged=True)
         assert isinstance(diffs, dict)
         assert "untracked" in diffs
         assert "unstaged" in diffs
         assert "staged" in diffs
 
-        # Test staged diff (through base commit comparison)
+        # Test HEAD comparison
         subprocess.run(["git", "add", "test.txt"], cwd=temp_git_repo, check=True)
-        staged_diffs = repo.get_diff(base_commit="HEAD")
+        staged_diffs = repo.get_diff(use_head=True)
         assert isinstance(staged_diffs, dict)
         assert "untracked" in staged_diffs
         assert "unstaged" in staged_diffs

--- a/tests/test_git_operations.py
+++ b/tests/test_git_operations.py
@@ -349,12 +349,17 @@ class TestGitRepositoryCommitComparison:
 
     @patch("difflicious.git_operations.GitRepository._execute_git_command")
     @patch("difflicious.git_operations.GitRepository.get_branches")
-    def test_get_diff_with_default_branch_comparison(self, mock_get_branches, mock_execute, mock_git_repo):
+    def test_get_diff_with_default_branch_comparison(
+        self, mock_get_branches, mock_execute, mock_git_repo
+    ):
         """Test get_diff with default branch comparison."""
         repo = GitRepository(str(mock_git_repo))
 
         # Mock get_branches to return main as default
-        mock_get_branches.return_value = {"default_branch": "main", "branches": ["main"]}
+        mock_get_branches.return_value = {
+            "default_branch": "main",
+            "branches": ["main"],
+        }
 
         # Mock git rev-parse for SHA validation and diff
         def mock_git_response(args):
@@ -408,17 +413,26 @@ class TestGitRepositoryCommitComparison:
             call for call in mock_execute.call_args_list if "diff" in call[0][0]
         ]
         assert len(diff_calls) > 0
-        diff_args = diff_calls[0][0][0]
-        assert "HEAD" in diff_args
+
+        # Check that at least one diff call contains HEAD
+        head_found = any("HEAD" in call[0][0] for call in diff_calls)
+        assert (
+            head_found
+        ), f"No diff call found with HEAD. Diff calls: {[call[0][0] for call in diff_calls]}"
 
     @patch("difflicious.git_operations.GitRepository._execute_git_command")
     @patch("difflicious.git_operations.GitRepository.get_branches")
-    def test_get_diff_untracked_files(self, mock_get_branches, mock_execute, mock_git_repo):
+    def test_get_diff_untracked_files(
+        self, mock_get_branches, mock_execute, mock_git_repo
+    ):
         """Test get_diff includes untracked files when requested."""
         repo = GitRepository(str(mock_git_repo))
 
         # Mock get_branches to return main as default
-        mock_get_branches.return_value = {"default_branch": "main", "branches": ["main"]}
+        mock_get_branches.return_value = {
+            "default_branch": "main",
+            "branches": ["main"],
+        }
 
         # Mock git responses
         def mock_git_response(args):
@@ -445,12 +459,17 @@ class TestGitRepositoryCommitComparison:
 
     @patch("difflicious.git_operations.GitRepository._execute_git_command")
     @patch("difflicious.git_operations.GitRepository.get_branches")
-    def test_get_diff_fallback_to_head(self, mock_get_branches, mock_execute, mock_git_repo):
+    def test_get_diff_fallback_to_head(
+        self, mock_get_branches, mock_execute, mock_git_repo
+    ):
         """Test get_diff falls back to HEAD when default branch doesn't exist."""
         repo = GitRepository(str(mock_git_repo))
 
         # Mock get_branches to return main as default, but main doesn't actually exist
-        mock_get_branches.return_value = {"default_branch": "main", "branches": ["main"]}
+        mock_get_branches.return_value = {
+            "default_branch": "main",
+            "branches": ["main"],
+        }
 
         # Mock git rev-parse responses
         def mock_git_response(args):

--- a/tests/test_git_operations.py
+++ b/tests/test_git_operations.py
@@ -416,7 +416,9 @@ class TestGitRepositoryCommitComparison:
         assert isinstance(diffs, dict)
         assert diffs["unstaged"]["count"] >= 0
         # Ensure feature-x appeared in diff args at least once
-        diff_calls = [call for call in mock_execute.call_args_list if "diff" in call[0][0]]
+        diff_calls = [
+            call for call in mock_execute.call_args_list if "diff" in call[0][0]
+        ]
         assert any("feature-x" in call[0][0] for call in diff_calls)
 
     @patch("difflicious.git_operations.GitRepository._execute_git_command")
@@ -488,7 +490,9 @@ class TestGitRepositoryCommitComparison:
         mock_execute.side_effect = resp
 
         # HEAD comparison with untracked/unstaged
-        out_head = repo.get_diff(use_head=True, include_unstaged=True, include_untracked=True)
+        out_head = repo.get_diff(
+            use_head=True, include_unstaged=True, include_untracked=True
+        )
         assert out_head["unstaged"]["count"] == 1
         assert out_head["untracked"]["count"] == 1
 


### PR DESCRIPTION
## Summary
This PR completes the simplification of our Git operations and diff data flow and standardizes on a single comparison parameter.

- Moves get_diff to a metadata-first implementation (merging --numstat and --name-status) and then fills per-file content lazily.
- Standardizes on base_ref end-to-end (repo -> service -> API -> templates -> frontend).
- Removes legacy commit-style parameters and mappings.

## BREAKING CHANGES
- API: /api/diff now uses base_ref exclusively. The legacy base_commit/target_commit parameters are removed.
- Response JSON includes base_ref (no base_commit/target_commit).
- Templates/UI: current_base_branch -> current_base_ref; toolbar select name changed to base_ref.
- Services: DiffService.get_grouped_diffs signature now accepts base_ref; TemplateRenderingService.prepare_diff_data_for_template now accepts base_ref.

## Comparison modes (unchanged conceptually)
1) Working directory vs HEAD (base_ref = HEAD or current branch): separate "staged" and "unstaged" groups.
2) Working directory vs default/arbitrary branch (base_ref = branch or None): combined "changes" group (staged + unstaged) plus optional "untracked".

## Highlights
- Default branch detection improved and cached (prefers remote HEAD; falls back to main/master/trunk).
- Faster status via summarize_changes for GitService.get_repository_status.
- Cross‑platform file utilities: replaced wc/sed with pure Python.
- Safer subprocess invocation: removed shlex quoting for list args, added GIT_OPTIONAL_LOCKS=0, strict option validation.
- New _resolve_base_ref() centralizes base selection (HEAD, default, or explicit base_ref).

## Tests
- Updated tests to reflect metadata-first get_diff and base_ref-only API.
- Added grouping behavior tests across HEAD/default/arbitrary bases and toggle combinations.
- All tests pass locally; ruff is clean.

## Migration notes
- Replace any usage of base_commit/target_commit with base_ref.
- Frontend/API callers should send base_ref and may include use_head=true for explicit HEAD mode.

## Follow-ups (separate PRs suggested)
- Consider pushing "changes" grouping into the repository layer to further simplify templates.
- Surface base_ref selection more explicitly in UI controls if needed.
