### PR TITLE
fix(diff): always include hunk headers; tidy base64 import

### DIFF
--- a/src/difflicious/app.py
+++ b/src/difflicious/app.py
@@ -1,5 +1,6 @@
 """Flask web application for Difflicious git diff visualization."""
 
+import base64
 import logging
 import os
 from typing import Union
@@ -411,8 +412,6 @@ def create_app() -> Flask:
             "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAQAAAC1+jfqAAAAHElEQVR4AWP4//8/AyWYGKAA"
             "GDAwMDAwQwYAAH7iB8o1s3BuAAAAAElFTkSuQmCC"
         )
-        import base64
-
         png_bytes = base64.b64decode(png_base64)
         return Response(png_bytes, mimetype="image/png")
 

--- a/src/difflicious/diff_parser.py
+++ b/src/difflicious/diff_parser.py
@@ -229,16 +229,15 @@ def create_side_by_side_lines(hunks: list[dict[str, Any]]) -> list[dict[str, Any
     side_by_side_lines = []
 
     for hunk in hunks:
-        # Add hunk header if present
-        if hunk.get("section_header"):
-            side_by_side_lines.append(
-                {
-                    "type": "hunk_header",
-                    "content": hunk["section_header"],
-                    "old_start": hunk["old_start"],
-                    "new_start": hunk["new_start"],
-                }
-            )
+        # Always add hunk header to ensure proper separation
+        side_by_side_lines.append(
+            {
+                "type": "hunk_header",
+                "content": hunk.get("section_header", ""),
+                "old_start": hunk["old_start"],
+                "new_start": hunk["new_start"],
+            }
+        )
 
         # Group consecutive additions and deletions for better alignment
         i = 0


### PR DESCRIPTION
## Summary
- Ensure side-by-side diffs always include a hunk header row for clear visual separation between hunks, even when a section header is absent.
- Move `base64` import to module scope in `app.py` to avoid per-request import within the favicon route.

## Test plan
- Start the app (`uv run difflicious`) and open a view with multiple hunks; verify each hunk displays a header separator consistently.
- Confirm the favicon serves correctly at `/favicon.ico` with no extra per-request import.
- Run test suite: `uv run pytest` (should pass).

## Notes
- No API or UI breaking changes; purely clarity and small hygiene improvement.