### PR TITLE
Rewrite README: logo header, cleaner structure, background blurb

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -78,3 +78,12 @@ jobs:
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
+
+    - name: Update Docker Hub description
+      if: github.event_name != 'pull_request'
+      uses: peter-evans/dockerhub-description@v4
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_HUB_TOKEN }}
+        repository: ${{ github.repository }}
+        readme-filepath: ./README.md

--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ difflicious() { docker run -it --rm -v "$PWD:/workspace" -p "${DIFFLICIOUS_PORT:
 - Light and dark themes
 - Live auto-reload on file changes (SSE)
 - Font customization via `DIFFLICIOUS_FONT` environment variable
+- Compare against any branch — defaults to remote HEAD, configurable per session
+- Toggle staged and unstaged changes independently
+- UI state is persistent — collapsed files, hidden files, and view settings are remembered in the browser across sessions
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ difflicious() { docker run -it --rm -v "$PWD:/workspace" -p "${DIFFLICIOUS_PORT:
 
 ## Features
 
+Everything you'd expect from a forge diff view, and a few things you wouldn't:
+
 - Side-by-side diff view with line numbering
 - Syntax highlighting for 100+ languages (via Pygments)
 - Context expansion to see more surrounding code

--- a/README.md
+++ b/README.md
@@ -69,16 +69,17 @@ Like your favourite forge, and then some:
 
 ## Configuration
 
-Set environment variables to configure behaviour:
+All options can be set via environment variable or CLI flag:
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `DIFFLICIOUS_PORT` | `5000` | Port to listen on |
-| `DIFFLICIOUS_HOST` | `127.0.0.1` | Host to bind to |
-| `DIFFLICIOUS_FONT` | `jetbrains-mono` | Code font (see `--list-fonts`) |
-| `DIFFLICIOUS_DISABLE_GOOGLE_FONTS` | `false` | Use system fonts only |
-| `DIFFLICIOUS_AUTO_RELOAD` | `true` | Auto-reload on file changes |
-| `DIFFLICIOUS_DEBUG` | `false` | Verbose debug logging |
+| Environment variable | CLI flag | Default | Description |
+|----------------------|----------|---------|-------------|
+| `DIFFLICIOUS_PORT` | `--port`, `-p` | `5000` | Port to listen on |
+| `DIFFLICIOUS_HOST` | `--host`, `-h` | `127.0.0.1` | Host to bind to |
+| `DIFFLICIOUS_FONT` | — | `jetbrains-mono` | Code font (`--list-fonts` to browse) |
+| `DIFFLICIOUS_DISABLE_GOOGLE_FONTS` | — | `false` | Use system fonts only |
+| `DIFFLICIOUS_AUTO_RELOAD` | `--auto-reload` / `--no-auto-reload` | `true` | Auto-reload on file changes |
+| `DIFFLICIOUS_WATCH_DEBOUNCE` | `--watch-debounce` | `1.0` | File watcher debounce delay (seconds) |
+| `DIFFLICIOUS_DEBUG` | `--debug` | `false` | Verbose debug logging |
 
 See [INSTALLATION.md](INSTALLATION.md) for full configuration details.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
+# Difflicious
+
 <div align="center">
   <img src="docs/site/assets/logo.png" width="160" alt="Difflicious">
-  <h1>Difflicious</h1>
-  <p>A local diff viewer for comparing your working directory to any branch, not just HEAD.<br>
-  No forge, no push — just run it in your repo.</p>
+  <p><em>A local diff viewer for comparing your working directory to any branch, not just HEAD.<br>
+  No forge, no push — just run it in your repo.</em></p>
 </div>
 
 ---
@@ -40,6 +41,16 @@ difflicious
 ```
 
 See [INSTALLATION.md](INSTALLATION.md) for Docker, source installation, and full configuration options.
+
+If you prefer not to install globally, add one of these to your shell profile:
+
+```bash
+# via uvx
+difflicious() { uvx difflicious "$@"; }
+
+# via Docker
+difflicious() { docker run -it --rm -v "$PWD:/workspace" -p 5000:5000 insipid/difflicious "$@"; }
+```
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -1,28 +1,43 @@
-# Difflicious
+<div align="center">
+  <img src="docs/site/assets/logo.png" width="160" alt="Difflicious">
+  <h1>Difflicious</h1>
+  <p>A local diff viewer for comparing your working directory to any branch, not just HEAD.<br>
+  No forge, no push — just run it in your repo.</p>
+</div>
 
-[![PyPI version](https://img.shields.io/pypi/v/difflicious.svg)](https://pypi.org/project/difflicious/)
-[![Python versions](https://img.shields.io/pypi/pyversions/difflicious.svg)](https://pypi.org/project/difflicious/)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-
-A local web application for reviewing git diffs. Run it in your working directory and view your changes in a browser with side-by-side visualization, syntax highlighting, and context expansion.
+---
 
 ## Screenshots
 
-| Light mode | Dark mode |
-|------------|-----------|
-| ![Light mode](docs/screenshots/light.png) | ![Dark mode](docs/screenshots/dark.png) |
+<p align="center">
+  <img src="docs/screenshots/light.png" width="49%" alt="Light mode">
+  <img src="docs/screenshots/dark.png" width="49%" alt="Dark mode">
+</p>
 
-> To regenerate: `uv run python scripts/screenshot.py`
-> Prerequisites: `uv add --dev playwright && uv run playwright install chromium`
+## Usage
+
+The quickest way — no install required:
+
+```bash
+uvx difflicious
+```
+
+Or with Docker:
+
+```bash
+docker run -it --rm -v "$PWD:/workspace" -p 5000:5000 insipid/difflicious
+```
+
+Then open `http://localhost:5000` in your browser.
 
 ## Installation
+
+For regular use, install from PyPI:
 
 ```bash
 pip install difflicious
 difflicious
 ```
-
-Open `http://localhost:5000` in your browser.
 
 See [INSTALLATION.md](INSTALLATION.md) for Docker, source installation, and full configuration options.
 
@@ -38,7 +53,7 @@ See [INSTALLATION.md](INSTALLATION.md) for Docker, source installation, and full
 
 ## Configuration
 
-Set environment variables to configure behavior:
+Set environment variables to configure behaviour:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -62,13 +77,14 @@ See [INSTALLATION.md](INSTALLATION.md) for full configuration details.
 - [INSTALLATION.md](INSTALLATION.md) — installation options, configuration, environment variables
 - [DEVELOPING.md](DEVELOPING.md) — development setup, testing, code conventions
 - [CHANGELOG.md](CHANGELOG.md) — version history
-- [docs/CSS-STYLE-GUIDE.md](docs/CSS-STYLE-GUIDE.md) — CSS conventions and design tokens
 - [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md) — common issues
 
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).
 
-## License
+---
 
-MIT License — see [LICENSE](LICENSE) file for details.
+[![PyPI version](https://img.shields.io/pypi/v/difflicious.svg)](https://pypi.org/project/difflicious/)
+[![Python versions](https://img.shields.io/pypi/pyversions/difflicious.svg)](https://pypi.org/project/difflicious/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ If you prefer not to install globally, add one of these to your shell profile:
 # via uvx
 difflicious() { uvx difflicious "$@"; }
 
-# via Docker
-difflicious() { docker run -it --rm -v "$PWD:/workspace" -p 5000:5000 insipid/difflicious "$@"; }
+# via Docker (uses DIFFLICIOUS_PORT if set, otherwise 5000)
+difflicious() { docker run -it --rm -v "$PWD:/workspace" -p "${DIFFLICIOUS_PORT:-5000}:${DIFFLICIOUS_PORT:-5000}" insipid/difflicious "$@"; }
 ```
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ difflicious() { docker run -it --rm -v "$PWD:/workspace" -p "${DIFFLICIOUS_PORT:
 
 ## Features
 
-Everything you'd expect from a forge diff view, and a few things you wouldn't:
+Like your favourite forge, and then some:
 
 - Side-by-side diff view with line numbering
 - Syntax highlighting for 100+ languages (via Pygments)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "difflicious"
 dynamic = ["version"]
-description = "A local diff viewer for comparing your working directory to any branch, not just HEAD"
+description = "A local web diff viewer for git diffs of a working directory"
 readme = "README.md"
 license = {text = "MIT"}
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "difflicious"
 dynamic = ["version"]
-description = "A sleek web-based git diff visualization tool for developers"
+description = "A local diff viewer for comparing your working directory to any branch, not just HEAD"
 readme = "README.md"
 license = {text = "MIT"}
 authors = [
@@ -93,6 +93,7 @@ testpaths = ["tests"]
 dev = [
     "black>=24.8.0",
     "mypy>=1.14.1",
+    "playwright>=1.58.0",
     "pytest>=8.3.5",
     "pytest-cov>=5.0.0",
     "ruff>=0.12.5",


### PR DESCRIPTION
## Changes

- Logo + name centered at top
- Background blurb: *"A local diff viewer for comparing your working directory to any branch, not just HEAD. No forge, no push — just run it in your repo."*
- Screenshots side by side (HTML img tags, no table, no captions, no regeneration instructions)
- Separate `## Usage` (uvx, docker) and `## Installation` (pip) sections restored
- Badges moved to the bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)