### PR TITLE
Site: switch theme to slate, build out content

### DIFF
--- a/docs/site/_config.yml
+++ b/docs/site/_config.yml
@@ -1,6 +1,6 @@
 title: Difflicious
 description: A local web application for reviewing git diffs
-theme: jekyll-theme-cayman
+theme: jekyll-theme-slate
 
 url: "https://insipid.github.io"
 baseurl: "/difflicious"


### PR DESCRIPTION
Ongoing PR for site content work. First commit switches theme from cayman to slate (dark charcoal header, light body).

Content to follow in subsequent commits once copy is approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)