### PR TITLE
PR 2: Remove UI state from template_service

### DIFF
--- a/src/difflicious/blueprints/views.py
+++ b/src/difflicious/blueprints/views.py
@@ -26,7 +26,6 @@ def index() -> str:
         base_ref = request.args.get("base_ref")
         file_path = request.args.get("file")
         search_filter = request.args.get("search", "").strip()
-        expand_files = request.args.get("expand", "false").lower() == "true"
 
         # If no base_ref specified, default to current checked-out branch to trigger HEAD comparison mode
         if not base_ref:
@@ -47,7 +46,6 @@ def index() -> str:
             base_ref=base_ref,
             file_path=file_path,
             search_filter=search_filter if search_filter else None,
-            expand_files=expand_files,
         )
 
         return render_template("index.html", **template_data)

--- a/src/difflicious/services/template_service.py
+++ b/src/difflicious/services/template_service.py
@@ -39,7 +39,6 @@ class TemplateRenderingService(BaseService):
         base_commit: Optional[str] = None,
         file_path: Optional[str] = None,
         search_filter: Optional[str] = None,
-        expand_files: bool = False,
         base_ref: Optional[str] = None,
     ) -> dict[str, Any]:
         """Prepare complete diff data optimized for Jinja2 template rendering.
@@ -50,8 +49,7 @@ class TemplateRenderingService(BaseService):
         Args:
             base_commit: Base commit for comparison
             file_path: Filter to specific file
-            search_filter: Search term for filtering files
-            expand_files: Whether to expand files by default
+            search_filter: Search term for filtering files (preserved in URL state)
             base_ref: Base reference for comparison (e.g., branch name or HEAD)
 
         Returns:
@@ -109,7 +107,7 @@ class TemplateRenderingService(BaseService):
 
             # Process and enhance diff data for template rendering
             enhanced_groups = self._enhance_diff_data_for_template(
-                grouped_diffs, search_filter, expand_files
+                grouped_diffs, search_filter
             )
 
             # Calculate totals
@@ -149,7 +147,6 @@ class TemplateRenderingService(BaseService):
         self,
         grouped_diffs: dict[str, Any],
         search_filter: Optional[str] = None,
-        expand_files: bool = False,
     ) -> dict[str, Any]:
         """Enhance diff data with syntax highlighting and template-specific features."""
 
@@ -159,19 +156,11 @@ class TemplateRenderingService(BaseService):
             enhanced_files: list[dict[str, Any]] = []
 
             for file_data in group_data.get("files", []):
-                # Check if this file matches the search filter (for initial display state)
-                # All files are included in HTML, but non-matching ones start hidden
-                matches_search = True
-                if search_filter is not None:
-                    file_path_lower = file_data.get("path", "").lower()
-                    search_lower = search_filter.lower()
-                    matches_search = search_lower in file_path_lower
-
                 # Add template-specific properties
+                # Note: hidden_by_search and expanded are client concerns — not set here
                 enhanced_file = {
                     **file_data,
-                    "expanded": expand_files,  # Control initial expansion state
-                    "hidden_by_search": not matches_search,  # Initial visibility state
+                    "file_id": f"{group_key}:{file_data.get('path', '')}",
                 }
 
                 # Process hunks with syntax highlighting
@@ -186,17 +175,9 @@ class TemplateRenderingService(BaseService):
 
                 enhanced_files.append(enhanced_file)
 
-            # Check if all files in this group are hidden by search
-            all_files_hidden = (
-                search_filter is not None
-                and len(enhanced_files) > 0
-                and all(f.get("hidden_by_search", False) for f in enhanced_files)
-            )
-
             enhanced_groups[group_key] = {
                 "files": enhanced_files,
                 "count": len(enhanced_files),
-                "hidden_by_search": all_files_hidden,  # Hide group container if all files hidden
             }
 
         return enhanced_groups

--- a/src/difflicious/templates/diff_file.html
+++ b/src/difflicious/templates/diff_file.html
@@ -1,10 +1,8 @@
 <!-- Single File Diff -->
-{% set file_id = group_name + ":" + file.path %}
 <div class="file-diff bg-neutral-50 dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-600 rounded-lg shadow-sm"
-    data-file="{{ file_id }}"
+    data-file="{{ file.file_id }}"
     {% if file.old_path %}data-old-path="{{ file.old_path }}"{% endif %}
-    x-data="fileComponent('{{ file_id }}')"
-    {% if file.hidden_by_search %}style="display: none;"{% endif %}>
+    x-data="fileComponent('{{ file.file_id }}')">
     <!-- File Header Wrapper -->
     <div class="file-header-wrapper">
         <!-- Spacer div to fill the gap -->
@@ -20,8 +18,8 @@
                 </span>
                 <span
                     class="expand-icon text-neutral-400 dark:text-neutral-600 hover:text-neutral-600 dark:hover:text-neutral-500 cursor-pointer transition-colors flex-shrink-0"
-                    onclick="loadFullDiff('{{ file.path }}', '{{ file_id }}'); event.stopPropagation()"
-                    title="Show complete file diff with unlimited context" id="expand-icon-{{ file_id }}">
+                    onclick="loadFullDiff('{{ file.path }}', '{{ file.file_id }}'); event.stopPropagation()"
+                    title="Show complete file diff with unlimited context" id="expand-icon-{{ file.file_id }}">
                     ↕
                 </span>
                 <div class="flex-1 min-w-0 break-words">
@@ -63,12 +61,12 @@
 
                 <!-- File Navigation -->
                 <div class="flex items-center space-x-1" onclick="event.stopPropagation()">
-                    <button onclick="navigateToPreviousFile('{{ file_id }}')"
+                    <button onclick="navigateToPreviousFile('{{ file.file_id }}')"
                         class="p-1 text-neutral-400 dark:text-neutral-600 hover:text-neutral-600 dark:hover:text-neutral-500 hover:bg-neutral-100 dark:hover:bg-neutral-700 rounded transition-colors"
                         title="Previous file">
                         <span class="text-sm">↑</span>
                     </button>
-                    <button onclick="navigateToNextFile('{{ file_id }}')"
+                    <button onclick="navigateToNextFile('{{ file.file_id }}')"
                         class="p-1 text-neutral-400 dark:text-neutral-600 hover:text-neutral-600 dark:hover:text-neutral-500 hover:bg-neutral-100 dark:hover:bg-neutral-700 rounded transition-colors"
                         title="Next file">
                         <span class="text-sm">↓</span>
@@ -79,7 +77,7 @@
     </div>
 
     <!-- File Content -->
-    <div class="file-content" data-file-content="{{ file_id }}"
+    <div class="file-content" data-file-content="{{ file.file_id }}"
         x-show="isExpanded"
         x-cloak
         x-transition:enter="transition ease-out duration-200"

--- a/tests/services/test_template_service.py
+++ b/tests/services/test_template_service.py
@@ -188,19 +188,14 @@ class TestTemplateRenderingService:
         # Test with search filter
         result = service.prepare_diff_data_for_template(search_filter="test")
 
-        # All files should be included, but non-matching ones should be marked as hidden
+        # All files should be included — filtering is a client concern
         # When no base_commit is provided, unstaged and staged are combined into "changes"
         assert result["groups"]["changes"]["count"] == 3
         files = result["groups"]["changes"]["files"]
         assert len(files) == 3
-        # test.py should match (not hidden)
-        test_py = next(f for f in files if f["path"] == "test.py")
-        assert test_py.get("hidden_by_search", False) is False
-        # example.js and other.txt should not match (hidden)
-        example_js = next(f for f in files if f["path"] == "example.js")
-        assert example_js.get("hidden_by_search", False) is True
-        other_txt = next(f for f in files if f["path"] == "other.txt")
-        assert other_txt.get("hidden_by_search", False) is True
+        # No file should have hidden_by_search set (client concern)
+        for f in files:
+            assert "hidden_by_search" not in f
 
     def test_process_line_side_with_content(self):
         """Test processing line side with content."""
@@ -329,14 +324,13 @@ class TestTemplateRenderingService:
             }
         }
 
-        result = self.service._enhance_diff_data_for_template(
-            grouped_diffs, expand_files=True
-        )
+        result = self.service._enhance_diff_data_for_template(grouped_diffs)
 
         assert "unstaged" in result
         assert result["unstaged"]["count"] == 1
         assert len(result["unstaged"]["files"]) == 1
-        assert result["unstaged"]["files"][0]["expanded"] is True
+        # expanded is a client concern — must not be set by the service
+        assert "expanded" not in result["unstaged"]["files"][0]
 
     def test_enhance_diff_data_with_search_filter(self):
         """Test enhancing diff data with search filter."""
@@ -353,17 +347,14 @@ class TestTemplateRenderingService:
             grouped_diffs, search_filter="test"
         )
 
-        # All files should be included, but non-matching ones marked as hidden
+        # All files should be included — filtering is a client concern
         assert result["unstaged"]["count"] == 2
         assert len(result["unstaged"]["files"]) == 2
-        # test.py should not be hidden
-        test_py = next(f for f in result["unstaged"]["files"] if f["path"] == "test.py")
-        assert test_py.get("hidden_by_search", False) is False
-        # example.js should be hidden
-        example_js = next(
-            f for f in result["unstaged"]["files"] if f["path"] == "example.js"
-        )
-        assert example_js.get("hidden_by_search", False) is True
+        # No file should have hidden_by_search set
+        for f in result["unstaged"]["files"]:
+            assert "hidden_by_search" not in f
+        # Group should not have hidden_by_search either
+        assert "hidden_by_search" not in result["unstaged"]
 
     @patch("difflicious.services.template_service.DiffService")
     @patch("difflicious.services.template_service.GitService")
@@ -398,3 +389,63 @@ class TestTemplateRenderingService:
         assert "repo_status" in result
         assert "branches" in result
         assert "groups" in result
+
+    def test_enhanced_file_has_no_hidden_by_search_flag(self):
+        """Service must not produce hidden_by_search — that is a client concern."""
+        service = TemplateRenderingService()
+        result = service._enhance_diff_data_for_template(
+            {
+                "unstaged": {
+                    "files": [{"path": "foo.py", "status": "modified", "hunks": []}],
+                    "count": 1,
+                }
+            },
+            search_filter="bar",  # does NOT match "foo.py"
+        )
+        files = result["unstaged"]["files"]
+        assert len(files) == 1
+        assert "hidden_by_search" not in files[0]
+
+    def test_enhanced_file_has_no_expanded_flag(self):
+        """Service must not produce expanded — initial UI state is a client concern."""
+        service = TemplateRenderingService()
+        result = service._enhance_diff_data_for_template(
+            {
+                "unstaged": {
+                    "files": [{"path": "foo.py", "status": "modified", "hunks": []}],
+                    "count": 1,
+                }
+            },
+        )
+        files = result["unstaged"]["files"]
+        assert "expanded" not in files[0]
+
+    def test_enhanced_file_has_file_id(self):
+        """Service must compute file_id for each file."""
+        service = TemplateRenderingService()
+        result = service._enhance_diff_data_for_template(
+            {
+                "unstaged": {
+                    "files": [
+                        {"path": "src/foo.py", "status": "modified", "hunks": []}
+                    ],
+                    "count": 1,
+                }
+            },
+        )
+        files = result["unstaged"]["files"]
+        assert files[0]["file_id"] == "unstaged:src/foo.py"
+
+    def test_group_has_no_hidden_by_search_flag(self):
+        """Group-level hidden_by_search must not be produced."""
+        service = TemplateRenderingService()
+        result = service._enhance_diff_data_for_template(
+            {
+                "unstaged": {
+                    "files": [{"path": "foo.py", "status": "modified", "hunks": []}],
+                    "count": 1,
+                }
+            },
+            search_filter="zzz",
+        )
+        assert "hidden_by_search" not in result["unstaged"]


### PR DESCRIPTION
## Summary

- Removes `hidden_by_search` and `expanded` flags from `template_service._enhance_diff_data_for_template` — these are client concerns, not service concerns
- Adds `file_id` computation to service output (`{group_key}:{file.path}`)
- Removes `{% set file_id %}` computation from `diff_file.html`; template now reads `file.file_id` from the service
- Removes `expand_files` parameter from service layer and `views.py` (the `?expand=true` URL param no longer does anything — initial expansion is now a client concern)
- Adds 4 new tests asserting the service no longer produces UI state flags

Part of the presentation-layer-separation plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)