### PR TITLE
PR 3: Extract toolbar inline script to toolbarComponent

### DIFF
--- a/src/difflicious/static/js/alpine-init.js
+++ b/src/difflicious/static/js/alpine-init.js
@@ -22,12 +22,14 @@ import { fileComponent } from './components/fileComponent.js';
 import { groupComponent } from './components/groupComponent.js';
 import { searchComponent } from './components/searchComponent.js';
 import { hunkComponent } from './components/hunkComponent.js';
+import { toolbarComponent } from './modules/toolbar.js';
 
 // Register component factories globally BEFORE Alpine starts
 window.fileComponent = fileComponent;
 window.groupComponent = groupComponent;
 window.searchComponent = searchComponent;
 window.hunkComponent = hunkComponent;
+window.toolbarComponent = toolbarComponent;
 
 // Export Alpine for use in components
 window.Alpine = Alpine;

--- a/src/difflicious/static/js/modules/toolbar.js
+++ b/src/difflicious/static/js/modules/toolbar.js
@@ -1,0 +1,52 @@
+/**
+ * Toolbar Alpine component
+ * Manages client-side visibility of unstaged/untracked groups
+ * and form submission hygiene. Extracted from toolbar.html inline script.
+ */
+
+/**
+ * @param {boolean} initialUnstaged - Server-rendered initial unstaged toggle state
+ * @param {boolean} initialUntracked - Server-rendered initial untracked toggle state
+ * @returns {object} Alpine component object
+ */
+export function toolbarComponent(initialUnstaged, initialUntracked) {
+    return {
+        unstaged: initialUnstaged,
+        untracked: initialUntracked,
+
+        init() {
+            this.updateGroupVisibility();
+        },
+
+        updateToggle(name, checked) {
+            this[name] = checked;
+            this.updateGroupVisibility();
+            this.updateURL();
+        },
+
+        updateGroupVisibility() {
+            const unstagedGroup = document.querySelector('[data-group="unstaged"]');
+            const untrackedGroup = document.querySelector('[data-group="untracked"]');
+            if (unstagedGroup) unstagedGroup.style.display = this.unstaged ? '' : 'none';
+            if (untrackedGroup) untrackedGroup.style.display = this.untracked ? '' : 'none';
+        },
+
+        updateURL() {
+            const url = new URL(window.location.href);
+            url.searchParams.set('unstaged', this.unstaged.toString());
+            url.searchParams.set('untracked', this.untracked.toString());
+            window.history.replaceState({}, '', url);
+        },
+
+        scrubEmptySearch(form) {
+            const searchInput = form.querySelector('input[name="search"]');
+            if (searchInput && (!searchInput.value || searchInput.value.trim() === '')) {
+                searchInput.name = '';
+            }
+        }
+    };
+}
+
+if (typeof window !== 'undefined') {
+    window.toolbarComponent = toolbarComponent;
+}

--- a/src/difflicious/templates/partials/toolbar.html
+++ b/src/difflicious/templates/partials/toolbar.html
@@ -1,5 +1,6 @@
 <!-- Toolbar -->
-<header class="bg-neutral-50 dark:bg-neutral-800 border-b border-neutral-200 dark:border-neutral-600 px-4 py-3">
+<header x-data="toolbarComponent({{ unstaged|lower }}, {{ untracked|lower }})"
+    class="bg-neutral-50 dark:bg-neutral-800 border-b border-neutral-200 dark:border-neutral-600 px-4 py-3">
     <div class="flex items-center justify-between">
         <div class="flex items-center space-x-4 flex-1">
             <h1 class="text-xl font-semibold text-neutral-900 dark:text-neutral-300">
@@ -8,7 +9,7 @@
 
             <!-- Base Branch Dropdown -->
             <form method="GET" action="/" class="flex items-center space-x-2 flex-1"
-                onsubmit="return scrubEmptyInputs(this)"
+                @submit="scrubEmptySearch($el)"
                 id="diff-toolbar-form">
                 <label class="text-sm font-medium text-neutral-700 dark:text-neutral-400">
                     <svg width="20" height="20" viewBox="0 0 512 512" fill="currentColor" class="inline" title="Branch"
@@ -33,7 +34,8 @@
                     <!-- HEAD comparison: show "Untracked" and "Unstaged" (staged always visible) -->
                     <label class="flex items-center">
                         <input type="checkbox" name="untracked" value="true" {% if untracked %}checked{% endif %}
-                            class="h-4 w-4 text-info-text-600 focus:ring-info-text-600 border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-700 rounded checkbox-control">
+                            @change.stop="updateToggle('untracked', $event.target.checked)"
+                            class="h-4 w-4 text-info-text-600 focus:ring-info-text-600 border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-700 rounded">
                         <svg width="20" height="20" viewBox="0 0 1024 1024" fill="currentColor"
                             class="ml-1 text-neutral-700 dark:text-neutral-300" title="Untracked"
                             aria-label="Untracked">
@@ -45,7 +47,8 @@
 
                     <label class="flex items-center">
                         <input type="checkbox" name="unstaged" value="true" {% if unstaged %}checked{% endif %}
-                            class="h-4 w-4 text-info-text-600 focus:ring-info-text-600 border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-700 rounded checkbox-control">
+                            @change.stop="updateToggle('unstaged', $event.target.checked)"
+                            class="h-4 w-4 text-info-text-600 focus:ring-info-text-600 border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-700 rounded">
                         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
                             stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
                             class="ml-1 text-neutral-700 dark:text-neutral-400" title="Unstaged" aria-label="Unstaged">
@@ -62,7 +65,8 @@
                     <!-- Branch comparison: only show "Untracked" (changes are always visible) -->
                     <label class="flex items-center">
                         <input type="checkbox" name="untracked" value="true" {% if untracked %}checked{% endif %}
-                            class="h-4 w-4 text-info-text-600 focus:ring-info-text-600 border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-700 rounded checkbox-control">
+                            @change.stop="updateToggle('untracked', $event.target.checked)"
+                            class="h-4 w-4 text-info-text-600 focus:ring-info-text-600 border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-700 rounded">
                         <svg width="20" height="20" viewBox="0 0 1024 1024" fill="currentColor"
                             class="ml-1 text-neutral-700 dark:text-neutral-400" title="Untracked"
                             aria-label="Untracked">
@@ -113,126 +117,3 @@
         </div>
     </div>
 </header>
-
-<script>
-    // Global state for toggle visibility (client-side filtering)
-    const ToggleState = {
-        unstaged: {{ unstaged|lower }},
-        untracked: {{ untracked|lower }},
-
-        updateToggle(name, checked) {
-            this[name] = checked;
-            this.updateGroupVisibility();
-            this.updateURL();
-        },
-
-        updateGroupVisibility() {
-            // Show/hide groups based on toggle state without server request
-            const unstagedGroup = document.querySelector('[data-group="unstaged"]');
-            const untrackedGroup = document.querySelector('[data-group="untracked"]');
-
-            if (unstagedGroup) {
-                unstagedGroup.style.display = this.unstaged ? '' : 'none';
-            }
-
-            if (untrackedGroup) {
-                untrackedGroup.style.display = this.untracked ? '' : 'none';
-            }
-        },
-
-        updateURL() {
-            // Update URL without page reload for bookmarking/sharing
-            const url = new URL(window.location);
-            url.searchParams.set('unstaged', this.unstaged.toString());
-            url.searchParams.set('untracked', this.untracked.toString());
-            window.history.replaceState({}, '', url);
-        }
-    };
-
-    function updateCheckboxAndSubmit(checkbox) {
-        // This function is called for non-toggle checkboxes only
-        // Toggles are handled in the event listener directly
-
-        // For other form elements (branch select, search), submit normally
-        const form = checkbox.form;
-        const formData = new FormData(form);
-        const params = new URLSearchParams();
-
-        // Get all form data except checkboxes (we'll handle those explicitly)
-        for (const [key, value] of formData.entries()) {
-            if (key !== 'unstaged' && key !== 'staged' && key !== 'untracked') {
-                // Skip empty-ish search values
-                if (key === 'search' && (!value || value.trim() === '')) {
-                    continue;
-                }
-                params.set(key, value);
-            }
-        }
-
-        // Include current toggle states in URL
-        params.set('unstaged', ToggleState.unstaged.toString());
-        params.set('untracked', ToggleState.untracked.toString());
-
-        // Explicitly set checkbox states based on their current checked state
-        const unstagedCheckbox = form.querySelector('input[name="unstaged"]');
-        const stagedCheckbox = form.querySelector('input[name="staged"]');
-        const untrackedCheckbox = form.querySelector('input[name="untracked"]');
-
-        if (unstagedCheckbox) {
-            params.set('unstaged', unstagedCheckbox.checked ? 'true' : 'false');
-        }
-        if (stagedCheckbox) {
-            // Only set staged parameter if staged checkbox exists (not in HEAD comparisons)
-            params.set('staged', stagedCheckbox.checked ? 'true' : 'false');
-        }
-        if (untrackedCheckbox) {
-            params.set('untracked', untrackedCheckbox.checked ? 'true' : 'false');
-        }
-
-        // Navigate to the updated URL
-        window.location.href = '?' + params.toString();
-    }
-
-    function scrubEmptyInputs(form) {
-        // Prevent submitting empty search to avoid blank search param
-        const searchInput = form.querySelector('input[name="search"]');
-        if (searchInput && (!searchInput.value || searchInput.value.trim() === '')) {
-            searchInput.name = '';
-        }
-        return true;
-    }
-
-    // Set up event listeners when DOM is ready
-    // Use capture phase to ensure our handler runs before other listeners
-    document.addEventListener('DOMContentLoaded', function () {
-        // Initialize toggle state based on initial visibility
-        ToggleState.updateGroupVisibility();
-
-        const form = document.getElementById('diff-toolbar-form');
-        const checkboxes = document.querySelectorAll('input[name="unstaged"], input[name="untracked"]');
-
-        // Prevent form submission when unstaged/untracked toggles change
-        if (form) {
-            form.addEventListener('submit', function(event) {
-                const target = event.target || event.submitter;
-                // Check if submit was triggered by unstaged/untracked checkbox change
-                if (target && (target.name === 'unstaged' || target.name === 'untracked')) {
-                    event.preventDefault();
-                    event.stopPropagation();
-                    return false;
-                }
-            }, true);
-        }
-
-        checkboxes.forEach(function (checkbox) {
-            // Use capture phase and stopImmediatePropagation to ensure our handler runs first
-            checkbox.addEventListener('change', function (event) {
-                // For unstaged/untracked toggles, use client-side filtering
-                event.preventDefault();
-                event.stopPropagation();
-                event.stopImmediatePropagation();
-                ToggleState.updateToggle(checkbox.name, checkbox.checked);
-            }, true); // Use capture phase
-        });
-    });
-</script>

--- a/tests/js/toolbar.test.js
+++ b/tests/js/toolbar.test.js
@@ -1,0 +1,42 @@
+import { toolbarComponent } from '../../src/difflicious/static/js/modules/toolbar.js';
+
+describe('toolbarComponent', () => {
+    let comp;
+
+    beforeEach(() => {
+        document.body.innerHTML = `
+            <div data-group="unstaged" style="display:none"></div>
+            <div data-group="untracked" style="display:none"></div>
+        `;
+        comp = toolbarComponent(true, false); // unstaged=true, untracked=false
+        comp.init();
+    });
+
+    test('init applies initial visibility', () => {
+        const unstaged = document.querySelector('[data-group="unstaged"]');
+        const untracked = document.querySelector('[data-group="untracked"]');
+        expect(unstaged.style.display).toBe('');
+        expect(untracked.style.display).toBe('none');
+    });
+
+    test('updateToggle changes state and updates DOM', () => {
+        comp.updateToggle('untracked', true);
+        expect(comp.untracked).toBe(true);
+        const el = document.querySelector('[data-group="untracked"]');
+        expect(el.style.display).toBe('');
+    });
+
+    test('scrubEmptySearch clears field name when blank', () => {
+        document.body.innerHTML += '<form><input name="search" value="   "></form>';
+        const form = document.querySelector('form');
+        comp.scrubEmptySearch(form);
+        expect(form.querySelector('[name="search"]')).toBeNull();
+    });
+
+    test('scrubEmptySearch leaves field name when value present', () => {
+        document.body.innerHTML += '<form><input name="search" value="foo"></form>';
+        const form = document.querySelector('form');
+        comp.scrubEmptySearch(form);
+        expect(form.querySelector('[name="search"]')).not.toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary

- Creates `src/difflicious/static/js/modules/toolbar.js` with an Alpine component factory (`toolbarComponent`) that manages client-side unstaged/untracked group visibility and form hygiene
- Registers `toolbarComponent` in `alpine-init.js` alongside the other component factories
- Replaces the 120-line `<script>` block in `toolbar.html` with a single `x-data` binding on the `<header>` element
- Replaces `onsubmit="return scrubEmptyInputs(this)"` with `@submit="scrubEmptySearch($el)"`
- Replaces `checkbox-control` + DOMContentLoaded event listeners with `@change.stop="updateToggle(...)"` Alpine directives on each checkbox
- Adds 4 Jest tests covering init visibility, toggle behaviour, and search scrubbing

Part of the presentation-layer-separation plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)