### PR TITLE
PR 5: Replace template onclick strings with Alpine store directives

### DIFF
--- a/src/difflicious/static/js/stores/diffStore.js
+++ b/src/difflicious/static/js/stores/diffStore.js
@@ -4,6 +4,10 @@
  * Using objects instead of Sets for better Alpine.js reactivity
  */
 
+import { expandContext as _expandContext } from '../modules/context-expansion.js';
+import { loadFullDiff as _loadFullDiff, loadMovedFileContent as _loadMovedFileContent } from '../modules/full-diff.js';
+import { navigateToPreviousFile as _navigateToPrev, navigateToNextFile as _navigateToNext } from '../modules/navigation.js';
+
 // Debug flag - reads from DIFFLICIOUS_DEBUG env var (set in base.html template)
 const DEBUG = window.DIFFLICIOUS_DEBUG || false;
 
@@ -184,6 +188,47 @@ export default {
             lastUpdated: new Date().toISOString()
         };
         localStorage.setItem(this.storageKey, JSON.stringify(state));
+    },
+
+    /**
+     * Expand context lines — called by @click="$store.diff.expandContext($el)"
+     * Reads data-file-path, data-hunk-index, data-direction from the button element.
+     */
+    expandContext(el) {
+        const filePath = el.dataset.filePath;
+        const hunkIndex = parseInt(el.dataset.hunkIndex, 10);
+        const direction = el.dataset.direction;
+        _expandContext(el, filePath, hunkIndex, direction, 10, 'pygments');
+    },
+
+    /**
+     * Load full diff — called by @click="$store.diff.loadFullDiff($el)"
+     * Reads data-file-path and data-file-id from the element.
+     */
+    loadFullDiff(el) {
+        _loadFullDiff(el.dataset.filePath, el.dataset.fileId);
+    },
+
+    /**
+     * Load moved file content — called by @click="$store.diff.loadMovedFileContent($el)"
+     * Passes the element directly; full-diff.js reads data-file-path / data-old-path from parent.
+     */
+    loadMovedFileContent(el) {
+        _loadMovedFileContent(el);
+    },
+
+    /**
+     * Navigate to previous file — called by @click="$store.diff.navigateToPreviousFile($el)"
+     */
+    navigateToPreviousFile(el) {
+        _navigateToPrev(el.dataset.fileId);
+    },
+
+    /**
+     * Navigate to next file — called by @click="$store.diff.navigateToNextFile($el)"
+     */
+    navigateToNextFile(el) {
+        _navigateToNext(el.dataset.fileId);
     },
 
     /**

--- a/src/difflicious/templates/diff_file.html
+++ b/src/difflicious/templates/diff_file.html
@@ -18,7 +18,9 @@
                 </span>
                 <span
                     class="expand-icon text-neutral-400 dark:text-neutral-600 hover:text-neutral-600 dark:hover:text-neutral-500 cursor-pointer transition-colors flex-shrink-0"
-                    onclick="loadFullDiff('{{ file.path }}', '{{ file.file_id }}'); event.stopPropagation()"
+                    @click.stop="$store.diff.loadFullDiff($el)"
+                    data-file-path="{{ file.path }}"
+                    data-file-id="{{ file.file_id }}"
                     title="Show complete file diff with unlimited context" id="expand-icon-{{ file.file_id }}">
                     ↕
                 </span>
@@ -61,12 +63,14 @@
 
                 <!-- File Navigation -->
                 <div class="flex items-center space-x-1" onclick="event.stopPropagation()">
-                    <button onclick="navigateToPreviousFile('{{ file.file_id }}')"
+                    <button @click="$store.diff.navigateToPreviousFile($el)"
+                        data-file-id="{{ file.file_id }}"
                         class="p-1 text-neutral-400 dark:text-neutral-600 hover:text-neutral-600 dark:hover:text-neutral-500 hover:bg-neutral-100 dark:hover:bg-neutral-700 rounded transition-colors"
                         title="Previous file">
                         <span class="text-sm">↑</span>
                     </button>
-                    <button onclick="navigateToNextFile('{{ file.file_id }}')"
+                    <button @click="$store.diff.navigateToNextFile($el)"
+                        data-file-id="{{ file.file_id }}"
                         class="p-1 text-neutral-400 dark:text-neutral-600 hover:text-neutral-600 dark:hover:text-neutral-500 hover:bg-neutral-100 dark:hover:bg-neutral-700 rounded transition-colors"
                         title="Next file">
                         <span class="text-sm">↓</span>
@@ -95,7 +99,7 @@
                 <div class="flex-1 border-r border-neutral-200 dark:border-neutral-600">
                     <div class="flex">
                         <div class="w-12 hunk-expansion-linenum border-r select-none flex flex-col">
-                            <button onclick="loadMovedFileContent(this)"
+                            <button @click="$store.diff.loadMovedFileContent($el)"
                                 class="expansion-btn w-full px-2 py-1 text-xs hunk-expansion-btn transition-colors flex items-center justify-center h-full"
                                 title="Show file content">
                                 ↕
@@ -110,7 +114,7 @@
                 <div class="flex-1">
                     <div class="flex">
                         <div class="w-12 hunk-expansion-linenum border-r select-none flex flex-col">
-                            <button onclick="loadMovedFileContent(this)"
+                            <button @click="$store.diff.loadMovedFileContent($el)"
                                 class="expansion-btn w-full px-2 py-1 text-xs hunk-expansion-btn transition-colors flex items-center justify-center h-full"
                                 title="Show file content">
                                 ↕

--- a/src/difflicious/templates/diff_hunk.html
+++ b/src/difflicious/templates/diff_hunk.html
@@ -10,8 +10,10 @@
         <div class="flex-1 border-r border-neutral-200 dark:border-neutral-600">
             <div class="flex">
                 <div class="w-12 hunk-expansion-linenum border-r select-none flex flex-col">
-                    <button onclick="expandContext(this, '{{ file.path }}', {{ hunk.index }}, 'before', 10, 'pygments')"
+                    <button @click="$store.diff.expandContext($el)"
                         class="expansion-btn w-full px-2 py-1 text-xs hunk-expansion-btn transition-colors flex items-center justify-center h-full"
+                        data-file-path="{{ file.path }}"
+                        data-hunk-index="{{ hunk.index }}"
                         data-target-start="{{ hunk.expand_before_start }}"
                         data-target-end="{{ hunk.expand_before_end }}" data-direction="before"
                         title="Expand 10 lines up ({{ hunk.expand_before_start }}-{{ hunk.expand_before_end }})">
@@ -34,8 +36,10 @@
         <div class="flex-1">
             <div class="flex">
                 <div class="w-12 hunk-expansion-linenum border-r select-none flex flex-col">
-                    <button onclick="expandContext(this, '{{ file.path }}', {{ hunk.index }}, 'before', 10, 'pygments')"
+                    <button @click="$store.diff.expandContext($el)"
                         class="expansion-btn w-full px-2 py-1 text-xs hunk-expansion-btn transition-colors flex items-center justify-center h-full"
+                        data-file-path="{{ file.path }}"
+                        data-hunk-index="{{ hunk.index }}"
                         data-target-start="{{ hunk.expand_before_start }}"
                         data-target-end="{{ hunk.expand_before_end }}" data-direction="before"
                         title="Expand 10 lines up ({{ hunk.expand_before_start }}-{{ hunk.expand_before_end }})">
@@ -134,8 +138,10 @@
         <div class="flex-1 border-r border-neutral-200 dark:border-neutral-600">
             <div class="flex">
                 <div class="w-12 hunk-expansion-linenum border-r select-none flex flex-col">
-                    <button onclick="expandContext(this, '{{ file.path }}', {{ hunk.index }}, 'after', 10, 'pygments')"
+                    <button @click="$store.diff.expandContext($el)"
                         class="expansion-btn w-full px-2 py-1 text-xs hunk-expansion-btn transition-colors flex items-center justify-center h-full"
+                        data-file-path="{{ file.path }}"
+                        data-hunk-index="{{ hunk.index }}"
                         data-target-start="{{ hunk.expand_after_start }}" data-target-end="{{ hunk.expand_after_end }}"
                         data-direction="after"
                         title="Expand 10 lines down ({{ hunk.expand_after_start }}-{{ hunk.expand_after_end }})">
@@ -152,8 +158,10 @@
         <div class="flex-1">
             <div class="flex">
                 <div class="w-12 hunk-expansion-linenum border-r select-none flex flex-col">
-                    <button onclick="expandContext(this, '{{ file.path }}', {{ hunk.index }}, 'after', 10, 'pygments')"
+                    <button @click="$store.diff.expandContext($el)"
                         class="expansion-btn w-full px-2 py-1 text-xs hunk-expansion-btn transition-colors flex items-center justify-center h-full"
+                        data-file-path="{{ file.path }}"
+                        data-hunk-index="{{ hunk.index }}"
                         data-target-start="{{ hunk.expand_after_start }}" data-target-end="{{ hunk.expand_after_end }}"
                         data-direction="after"
                         title="Expand 10 lines down ({{ hunk.expand_after_start }}-{{ hunk.expand_after_end }})">

--- a/src/difflicious/templates/partials/global_controls.html
+++ b/src/difflicious/templates/partials/global_controls.html
@@ -1,7 +1,7 @@
 <!-- Global Controls -->
 <div class="flex items-center justify-between mb-4">
     <div class="flex items-center space-x-2">
-        <button id="expandAll" @click="window.expandAllFiles()"
+        <button id="expandAll" @click="$store.diff.expandAllFiles()"
             :disabled="$store.diff.allFilesExpanded"
             class="px-3 py-1 text-sm global-controls-btn flex items-center space-x-2"
             title="Expand All">
@@ -13,7 +13,7 @@
             </svg>
             <span>Expand All</span>
         </button>
-        <button id="collapseAll" @click="window.collapseAllFiles()"
+        <button id="collapseAll" @click="$store.diff.collapseAllFiles()"
             :disabled="$store.diff.allFilesCollapsed"
             class="px-3 py-1 text-sm global-controls-btn flex items-center space-x-2"
             title="Collapse All">

--- a/tests/js/diffStore-actions.test.js
+++ b/tests/js/diffStore-actions.test.js
@@ -1,0 +1,83 @@
+/**
+ * Tests for diffStore action methods added in PR5.
+ */
+
+const mockExpandContext = jest.fn();
+const mockLoadFullDiff = jest.fn();
+const mockLoadMovedFileContent = jest.fn();
+const mockNavigateToPreviousFile = jest.fn();
+const mockNavigateToNextFile = jest.fn();
+
+jest.unstable_mockModule('../../src/difflicious/static/js/modules/context-expansion.js', () => ({
+    expandContext: mockExpandContext,
+    setDebug: jest.fn(),
+    updateHunkRangeAfterExpansion: jest.fn(),
+}));
+jest.unstable_mockModule('../../src/difflicious/static/js/modules/full-diff.js', () => ({
+    loadFullDiff: mockLoadFullDiff,
+    loadMovedFileContent: mockLoadMovedFileContent,
+    renderFullDiff: jest.fn(),
+    renderSideBySideHunk: jest.fn(),
+    renderSideBySideLine: jest.fn(),
+}));
+jest.unstable_mockModule('../../src/difflicious/static/js/modules/navigation.js', () => ({
+    navigateToPreviousFile: mockNavigateToPreviousFile,
+    navigateToNextFile: mockNavigateToNextFile,
+}));
+
+const { default: diffStore } = await import('../../src/difflicious/static/js/stores/diffStore.js');
+
+describe('diffStore action methods', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('expandContext reads data-* from element and delegates', () => {
+        const el = document.createElement('button');
+        el.dataset.filePath = 'src/foo.py';
+        el.dataset.hunkIndex = '2';
+        el.dataset.direction = 'before';
+
+        diffStore.expandContext(el);
+
+        expect(mockExpandContext).toHaveBeenCalledWith(
+            el, 'src/foo.py', 2, 'before', 10, 'pygments'
+        );
+    });
+
+    test('loadFullDiff reads data-* from element and delegates', () => {
+        const el = document.createElement('span');
+        el.dataset.filePath = 'src/foo.py';
+        el.dataset.fileId = 'unstaged:src/foo.py';
+
+        diffStore.loadFullDiff(el);
+
+        expect(mockLoadFullDiff).toHaveBeenCalledWith('src/foo.py', 'unstaged:src/foo.py');
+    });
+
+    test('loadMovedFileContent passes element directly', () => {
+        const el = document.createElement('button');
+
+        diffStore.loadMovedFileContent(el);
+
+        expect(mockLoadMovedFileContent).toHaveBeenCalledWith(el);
+    });
+
+    test('navigateToPreviousFile reads data-file-id from element', () => {
+        const el = document.createElement('button');
+        el.dataset.fileId = 'unstaged:src/foo.py';
+
+        diffStore.navigateToPreviousFile(el);
+
+        expect(mockNavigateToPreviousFile).toHaveBeenCalledWith('unstaged:src/foo.py');
+    });
+
+    test('navigateToNextFile reads data-file-id from element', () => {
+        const el = document.createElement('button');
+        el.dataset.fileId = 'unstaged:src/foo.py';
+
+        diffStore.navigateToNextFile(el);
+
+        expect(mockNavigateToNextFile).toHaveBeenCalledWith('unstaged:src/foo.py');
+    });
+});


### PR DESCRIPTION
## Summary

- Adds 5 action methods to `diffStore.js` (`expandContext`, `loadFullDiff`, `loadMovedFileContent`, `navigateToPreviousFile`, `navigateToNextFile`), each reading `data-*` attributes from the clicked element and delegating to the existing JS modules via static imports
- **diff_hunk.html**: all 4 expansion buttons now use `@click="$store.diff.expandContext($el)"` with `data-file-path` and `data-hunk-index` attributes replacing the inline `onclick="expandContext(this, '...', ...)"` strings
- **diff_file.html**: expand icon, navigation arrows, and moved-file buttons all replaced with `@click="$store.diff.*($el)"` + `data-*` attributes
- **global_controls.html**: `window.expandAllFiles()` / `window.collapseAllFiles()` replaced with `$store.diff.expandAllFiles()` / `$store.diff.collapseAllFiles()`
- Adds 5 Jest tests for the new store action methods using `jest.unstable_mockModule`

Templates no longer know any JS function names or call signatures — they only declare intent via `data-*` attributes.

Part of the presentation-layer-separation plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)