### PR TITLE
refactor: simplify themeStore.init() to read theme from DOM only

### DIFF
--- a/src/difflicious/static/js/stores/themeStore.js
+++ b/src/difflicious/static/js/stores/themeStore.js
@@ -12,32 +12,17 @@ export default {
 
     /**
      * Initialize the theme store
+     * The inline script in base.html already applied localStorage/matchMedia
+     * before CSS loaded (to prevent FOUC), so we just mirror the DOM.
      */
     init() {
-        if (DEBUG) console.log('[ThemeStore] Initializing theme store...');
+        // Read the theme the inline script already committed to the DOM
+        const domTheme = document.documentElement.getAttribute('data-theme');
+        this.current = domTheme === 'dark' ? 'dark' : 'light';
 
-        const savedTheme = localStorage.getItem('difflicious-theme');
-        const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        if (DEBUG) console.log('[ThemeStore] Theme initialized from DOM:', this.current);
 
-        // Also check current DOM state (set by inline script)
-        const currentDomTheme = document.documentElement.getAttribute('data-theme');
-
-        this.current = savedTheme || currentDomTheme || (systemPrefersDark ? 'dark' : 'light');
-
-        if (DEBUG) {
-            console.log('[ThemeStore] Theme initialized:', {
-                savedTheme,
-                systemPrefersDark,
-                currentDomTheme,
-                current: this.current,
-                icon: this.icon
-            });
-        }
-
-        // Apply theme to document
-        this.applyTheme();
-
-        // Listen for system theme changes
+        // Listen for OS-level theme changes (only when user has no saved preference)
         window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
             if (!localStorage.getItem('difflicious-theme')) {
                 this.current = e.matches ? 'dark' : 'light';

--- a/tests/js/stores/themeStore.test.js
+++ b/tests/js/stores/themeStore.test.js
@@ -26,40 +26,35 @@ describe('themeStore', () => {
             expect(themeStore.current).toBe('light');
         });
 
-        it('should initialize from localStorage', () => {
-            localStorage.setItem('difflicious-theme', 'dark');
+        it('should initialize dark from DOM data-theme attribute', () => {
+            document.documentElement.setAttribute('data-theme', 'dark');
 
             themeStore.init();
 
             expect(themeStore.current).toBe('dark');
         });
 
-        it('should initialize from system preference when no saved theme', () => {
-            // Mock matchMedia to return dark preference
-            window.matchMedia = jest.fn().mockImplementation(query => ({
-                matches: query === '(prefers-color-scheme: dark)',
-                media: query,
-                addEventListener: jest.fn(),
-                removeEventListener: jest.fn()
-            }));
-
-            themeStore.init();
-
-            expect(themeStore.current).toBe('dark');
-        });
-
-        it('should default to light theme when no preference', () => {
-            // Mock matchMedia to return light preference
-            window.matchMedia = jest.fn().mockImplementation(query => ({
-                matches: false,
-                media: query,
-                addEventListener: jest.fn(),
-                removeEventListener: jest.fn()
-            }));
+        it('should initialize light when DOM data-theme is not dark', () => {
+            // data-theme not set (or set to 'light') → light
+            document.documentElement.removeAttribute('data-theme');
 
             themeStore.init();
 
             expect(themeStore.current).toBe('light');
+        });
+
+        it('should register system-preference change listener', () => {
+            const addEventListenerMock = jest.fn();
+            window.matchMedia = jest.fn().mockReturnValue({
+                matches: false,
+                media: '',
+                addEventListener: addEventListenerMock,
+                removeEventListener: jest.fn()
+            });
+
+            themeStore.init();
+
+            expect(addEventListenerMock).toHaveBeenCalledWith('change', expect.any(Function));
         });
     });
 


### PR DESCRIPTION
## Summary

- `themeStore.init()` previously duplicated the localStorage/matchMedia logic that the inline `<script>` in `base.html` already runs before any CSS loads (the FOUC-prevention script)
- Now `init()` simply reads `document.documentElement.getAttribute('data-theme')` — the single source of truth the inline script already committed to the DOM
- The OS-preference `matchMedia` change listener is kept so mid-session system theme changes still propagate when the user has no saved preference
- Updated `themeStore.test.js` to test the DOM-first contract instead of the old localStorage/matchMedia paths

## Test plan

- [x] All 142 JS tests pass (`pnpm run test:js`)
- [x] All 148 Python tests pass (`uv run pytest`)
- [x] ESLint clean (`pnpm run lint:js`)
- [x] `./cilicious.sh` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)