### PR TITLE
refactor: add js- prefix to pure JS-hook CSS selectors

### DIFF
--- a/src/difflicious/static/js/main.js
+++ b/src/difflicious/static/js/main.js
@@ -43,7 +43,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     // This runs once after state restoration is complete
     requestAnimationFrame(() => {
         if (DEBUG) console.log('Initializing expansion buttons...');
-        const buttons = $$('.expansion-btn');
+        const buttons = $$('.js-expansion-btn');
         buttons.forEach((button, index) => {
             const targetStart = parseInt(button.dataset.targetStart);
             const targetEnd = parseInt(button.dataset.targetEnd);

--- a/src/difflicious/static/js/modules/auto-reload.js
+++ b/src/difflicious/static/js/modules/auto-reload.js
@@ -146,7 +146,7 @@ export const AutoReload = {
         indicator.id = 'auto-reload-indicator';
         indicator.className = 'fixed bottom-4 right-4 px-2 py-1 text-xs rounded opacity-50 hover:opacity-100 transition-opacity';
         indicator.style.cssText = 'background: var(--surface-secondary); color: var(--text-secondary); pointer-events: auto; cursor: pointer; z-index: 1000;';
-        indicator.innerHTML = '<span class="connection-status">🟡 Auto-reload</span>';
+        indicator.innerHTML = '<span class="js-connection-status">🟡 Auto-reload</span>';
         indicator.title = 'Click to disable auto-reload';
 
         // Toggle on click
@@ -174,7 +174,7 @@ export const AutoReload = {
         const indicator = document.getElementById('auto-reload-indicator');
         if (!indicator) return;
 
-        const statusText = indicator.querySelector('.connection-status');
+        const statusText = indicator.querySelector('.js-connection-status');
         if (!statusText) return;
 
         const statusMessages = {

--- a/src/difflicious/static/js/modules/context-expansion-ui.js
+++ b/src/difflicious/static/js/modules/context-expansion-ui.js
@@ -45,7 +45,7 @@ export function createExpandedContextHtml(result, expansionId, triggerButton, di
 
     // Use the original working logic from before the broken refactoring
     const context = hunkContext(triggerButton);
-    const hunkLinesDiv = context?.currentHunk?.querySelector('.hunk-lines');
+    const hunkLinesDiv = context?.currentHunk?.querySelector('.js-hunk-lines');
 
     let startLineNumLeft, startLineNumRight;
 
@@ -137,7 +137,7 @@ export function createPlainContextHtml(result, expansionId, triggerButton, direc
 
     // Get line numbers from the hunk-lines data attributes
     const context = hunkContext(triggerButton);
-    const hunkLinesDiv = context?.currentHunk?.querySelector('.hunk-lines');
+    const hunkLinesDiv = context?.currentHunk?.querySelector('.js-hunk-lines');
 
     let startLineNumLeft, startLineNumRight;
 
@@ -252,7 +252,7 @@ export function insertExpandedContext(button, filePath, hunkIndex, direction, ex
 
     // Find the hunk lines container within this specific hunk
     const { currentHunk } = context;
-    const hunkLinesElement = currentHunk.querySelector('.hunk-lines');
+    const hunkLinesElement = currentHunk.querySelector('.js-hunk-lines');
     if (!hunkLinesElement) {
         if (DEBUG) console.error('Could not find hunk-lines element for insertion');
         return;
@@ -292,7 +292,7 @@ export function insertExpandedContext(button, filePath, hunkIndex, direction, ex
 export function updateHunkLinesDataAttributes(button, direction, linesAdded) {
     // Find the hunk-lines div and update its data attributes
     const context = hunkContext(button);
-    const hunkLinesDiv = context?.currentHunk?.querySelector('.hunk-lines');
+    const hunkLinesDiv = context?.currentHunk?.querySelector('.js-hunk-lines');
 
     if (!hunkLinesDiv) return;
 

--- a/src/difflicious/static/js/modules/full-diff.js
+++ b/src/difflicious/static/js/modules/full-diff.js
@@ -323,9 +323,9 @@ export function renderSideBySideHunk(hunk, filePath, hunkIndex) {
     }
 
     let html = `
-        <div class="hunk border-b border-neutral-100 last:border-b-0">
+        <div class="js-hunk border-b border-neutral-100 last:border-b-0">
             <!-- Hunk Lines -->
-            <div class="hunk-lines font-mono text-xs">
+            <div class="js-hunk-lines font-mono text-xs">
     `;
 
     if (hunk.lines && Array.isArray(hunk.lines)) {

--- a/src/difflicious/static/js/modules/hunk-operations.js
+++ b/src/difflicious/static/js/modules/hunk-operations.js
@@ -16,7 +16,7 @@ export function setDebug(value) {
  * @returns {Object|null} Hunk context with element references
  */
 export function hunkContext(button) {
-    const currentHunk = button.closest('.hunk');
+    const currentHunk = button.closest('.js-hunk');
     if (!currentHunk) {
         return null;
     }
@@ -26,7 +26,7 @@ export function hunkContext(button) {
         return { currentHunk, fileElement: null, allHunks: [], currentIndex: -1, prevHunk: null, nextHunk: null };
     }
 
-    const allHunks = Array.from(fileElement.querySelectorAll('.hunk'));
+    const allHunks = Array.from(fileElement.querySelectorAll('.js-hunk'));
     const currentIndex = allHunks.indexOf(currentHunk);
 
     return {
@@ -57,7 +57,7 @@ export function checkHunkAdjacency(button, direction, targetStart, targetEnd) {
             const nextHunkStart = parseInt(nextHunk.dataset.lineStart);
             if (targetEnd === nextHunkStart - 1) {
                 // Hide both before buttons in the next hunk (left and right sides)
-                const nextHunkBeforeBtns = nextHunk.querySelectorAll('.expansion-btn[data-direction="before"]');
+                const nextHunkBeforeBtns = nextHunk.querySelectorAll('.js-expansion-btn[data-direction="before"]');
                 nextHunkBeforeBtns.forEach(btn => {
                     btn.style.display = 'none';
                 });
@@ -66,7 +66,7 @@ export function checkHunkAdjacency(button, direction, targetStart, targetEnd) {
                 }
 
                 // Also hide all remaining after buttons in the current hunk since no more expansion is possible
-                const currentHunkAfterBtns = currentHunk.querySelectorAll('.expansion-btn[data-direction="after"]');
+                const currentHunkAfterBtns = currentHunk.querySelectorAll('.js-expansion-btn[data-direction="after"]');
                 currentHunkAfterBtns.forEach(btn => {
                     btn.style.display = 'none';
                 });
@@ -86,7 +86,7 @@ export function checkHunkAdjacency(button, direction, targetStart, targetEnd) {
             const prevHunkEnd = parseInt(prevHunk.dataset.lineEnd);
             if (targetStart <= prevHunkEnd + 1) {
                 // Hide both after buttons in the previous hunk (left and right sides)
-                const prevHunkAfterBtns = prevHunk.querySelectorAll('.expansion-btn[data-direction="after"]');
+                const prevHunkAfterBtns = prevHunk.querySelectorAll('.js-expansion-btn[data-direction="after"]');
                 prevHunkAfterBtns.forEach(btn => {
                     btn.style.display = 'none';
                 });
@@ -95,7 +95,7 @@ export function checkHunkAdjacency(button, direction, targetStart, targetEnd) {
                 }
 
                 // Also hide all remaining before buttons in the current hunk since no more expansion is possible
-                const currentHunkBeforeBtns = currentHunk.querySelectorAll('.expansion-btn[data-direction="before"]');
+                const currentHunkBeforeBtns = currentHunk.querySelectorAll('.js-expansion-btn[data-direction="before"]');
                 currentHunkBeforeBtns.forEach(btn => {
                     btn.style.display = 'none';
                 });
@@ -240,7 +240,7 @@ export function updateButtonForNextExpansion(button, direction, targetStart, tar
  */
 export function hideAllExpansionButtonsInHunk(triggerButton) {
     // Get the hunk element containing the trigger button
-    const hunkElement = triggerButton.closest('.hunk');
+    const hunkElement = triggerButton.closest('.js-hunk');
     if (!hunkElement) return;
 
     // Find the expansion bar within this hunk
@@ -248,7 +248,7 @@ export function hideAllExpansionButtonsInHunk(triggerButton) {
     if (!expansionBar) return;
 
     // Hide all expansion buttons in this hunk
-    const expansionButtons = expansionBar.querySelectorAll('.expansion-btn');
+    const expansionButtons = expansionBar.querySelectorAll('.js-expansion-btn');
     expansionButtons.forEach(btn => {
         btn.style.display = 'none';
         if (DEBUG) console.log(`Hiding ${btn.dataset.direction} button`);
@@ -265,7 +265,7 @@ export function hideExpansionBarIfAllButtonsHidden(triggerButton) {
     if (!expansionBar) return;
 
     // Check if all expansion buttons in this specific expansion bar are hidden
-    const expansionButtons = expansionBar.querySelectorAll('.expansion-btn');
+    const expansionButtons = expansionBar.querySelectorAll('.js-expansion-btn');
     const buttonStates = Array.from(expansionButtons).map(btn => ({
         direction: btn.dataset.direction,
         display: btn.style.display,

--- a/src/difflicious/templates/diff_file.html
+++ b/src/difflicious/templates/diff_file.html
@@ -100,7 +100,7 @@
                     <div class="flex">
                         <div class="w-12 hunk-expansion-linenum border-r select-none flex flex-col">
                             <button @click="$store.diff.loadMovedFileContent($el)"
-                                class="expansion-btn w-full px-2 py-1 text-xs hunk-expansion-btn transition-colors flex items-center justify-center h-full"
+                                class="js-expansion-btn w-full px-2 py-1 text-xs hunk-expansion-btn transition-colors flex items-center justify-center h-full"
                                 title="Show file content">
                                 ↕
                             </button>
@@ -115,7 +115,7 @@
                     <div class="flex">
                         <div class="w-12 hunk-expansion-linenum border-r select-none flex flex-col">
                             <button @click="$store.diff.loadMovedFileContent($el)"
-                                class="expansion-btn w-full px-2 py-1 text-xs hunk-expansion-btn transition-colors flex items-center justify-center h-full"
+                                class="js-expansion-btn w-full px-2 py-1 text-xs hunk-expansion-btn transition-colors flex items-center justify-center h-full"
                                 title="Show file content">
                                 ↕
                             </button>
@@ -149,7 +149,7 @@
             </div>
             <!-- Render all lines from the single hunk -->
             {% for hunk in file.hunks %}
-            <div class="hunk-lines">
+            <div class="js-hunk-lines">
                 {% for line in hunk.lines %}
                 <div class="diff-line flex line-{{ line.type }}">
                     <!-- Left Side: All deleted lines -->

--- a/src/difflicious/templates/diff_hunk.html
+++ b/src/difflicious/templates/diff_hunk.html
@@ -1,5 +1,5 @@
 <!-- Single Hunk -->
-<div class="hunk border-neutral-200 dark:border-neutral-600 last:border-b-0" data-line-start="{{ hunk.line_start }}"
+<div class="js-hunk border-neutral-200 dark:border-neutral-600 last:border-b-0" data-line-start="{{ hunk.line_start }}"
     data-line-end="{{ hunk.line_end }}" data-left-line-start="{{ hunk.left_start or 0 }}"
     data-left-line-end="{{ hunk.left_end or 0 }}">
 
@@ -11,7 +11,7 @@
             <div class="flex">
                 <div class="w-12 hunk-expansion-linenum border-r select-none flex flex-col">
                     <button @click="$store.diff.expandContext($el)"
-                        class="expansion-btn w-full px-2 py-1 text-xs hunk-expansion-btn transition-colors flex items-center justify-center h-full"
+                        class="js-expansion-btn w-full px-2 py-1 text-xs hunk-expansion-btn transition-colors flex items-center justify-center h-full"
                         data-file-path="{{ file.path }}"
                         data-hunk-index="{{ hunk.index }}"
                         data-target-start="{{ hunk.expand_before_start }}"
@@ -37,7 +37,7 @@
             <div class="flex">
                 <div class="w-12 hunk-expansion-linenum border-r select-none flex flex-col">
                     <button @click="$store.diff.expandContext($el)"
-                        class="expansion-btn w-full px-2 py-1 text-xs hunk-expansion-btn transition-colors flex items-center justify-center h-full"
+                        class="js-expansion-btn w-full px-2 py-1 text-xs hunk-expansion-btn transition-colors flex items-center justify-center h-full"
                         data-file-path="{{ file.path }}"
                         data-hunk-index="{{ hunk.index }}"
                         data-target-start="{{ hunk.expand_before_start }}"
@@ -55,7 +55,7 @@
     {% endif %}
 
     <!-- Hunk Lines -->
-    <div class="hunk-lines font-mono text-xs" data-left-start-line="{{ hunk.old_start }}"
+    <div class="js-hunk-lines font-mono text-xs" data-left-start-line="{{ hunk.old_start }}"
         data-left-end-line="{{ hunk.old_start + hunk.old_count - 1 }}" data-right-start-line="{{ hunk.new_start }}"
         data-right-end-line="{{ hunk.new_start + hunk.new_count - 1 }}">
         {% for line in hunk.lines %}
@@ -139,7 +139,7 @@
             <div class="flex">
                 <div class="w-12 hunk-expansion-linenum border-r select-none flex flex-col">
                     <button @click="$store.diff.expandContext($el)"
-                        class="expansion-btn w-full px-2 py-1 text-xs hunk-expansion-btn transition-colors flex items-center justify-center h-full"
+                        class="js-expansion-btn w-full px-2 py-1 text-xs hunk-expansion-btn transition-colors flex items-center justify-center h-full"
                         data-file-path="{{ file.path }}"
                         data-hunk-index="{{ hunk.index }}"
                         data-target-start="{{ hunk.expand_after_start }}" data-target-end="{{ hunk.expand_after_end }}"
@@ -159,7 +159,7 @@
             <div class="flex">
                 <div class="w-12 hunk-expansion-linenum border-r select-none flex flex-col">
                     <button @click="$store.diff.expandContext($el)"
-                        class="expansion-btn w-full px-2 py-1 text-xs hunk-expansion-btn transition-colors flex items-center justify-center h-full"
+                        class="js-expansion-btn w-full px-2 py-1 text-xs hunk-expansion-btn transition-colors flex items-center justify-center h-full"
                         data-file-path="{{ file.path }}"
                         data-hunk-index="{{ hunk.index }}"
                         data-target-start="{{ hunk.expand_after_start }}" data-target-end="{{ hunk.expand_after_end }}"

--- a/tests/js/auto-reload.test.js
+++ b/tests/js/auto-reload.test.js
@@ -37,7 +37,7 @@ describe('AutoReload', () => {
 
         const indicator = document.getElementById('auto-reload-indicator');
         expect(indicator).not.toBeNull();
-        expect(indicator.querySelector('.connection-status').textContent).toContain('Auto-reload');
+        expect(indicator.querySelector('.js-connection-status').textContent).toContain('Auto-reload');
     });
 
     it('handleConnectionError schedules reconnect', () => {

--- a/tests/js/context-expansion-ui.test.js
+++ b/tests/js/context-expansion-ui.test.js
@@ -12,20 +12,20 @@ import {
 const buildHunkWithLines = (direction = 'before') => {
     document.body.innerHTML = `
         <div data-file="src/test.js">
-            <div class="hunk">
-                <div class="hunk-lines"
+            <div class="js-hunk">
+                <div class="js-hunk-lines"
                     data-left-start-line="5"
                     data-left-end-line="10"
                     data-right-start-line="8"
                     data-right-end-line="13">
                     <div class="existing-line">Existing</div>
                 </div>
-                <button class="expansion-btn" data-direction="${direction}"></button>
+                <button class="js-expansion-btn" data-direction="${direction}"></button>
             </div>
         </div>
     `;
 
-    return document.querySelector('.expansion-btn');
+    return document.querySelector('.js-expansion-btn');
 };
 
 describe('injectPygmentsCss', () => {
@@ -65,7 +65,7 @@ describe('insertExpandedContext', () => {
             '<div class="expanded-context">New</div>'
         );
 
-        const hunkLines = document.querySelector('.hunk-lines');
+        const hunkLines = document.querySelector('.js-hunk-lines');
         expect(hunkLines.firstElementChild.classList.contains('expanded-context')).toBe(true);
     });
 });
@@ -75,7 +75,7 @@ describe('updateHunkLinesDataAttributes', () => {
         const button = buildHunkWithLines('before');
         updateHunkLinesDataAttributes(button, 'before', 2);
 
-        const hunkLines = document.querySelector('.hunk-lines');
+        const hunkLines = document.querySelector('.js-hunk-lines');
         expect(hunkLines.dataset.leftStartLine).toBe('3');
         expect(hunkLines.dataset.rightStartLine).toBe('6');
     });

--- a/tests/js/context-expansion.test.js
+++ b/tests/js/context-expansion.test.js
@@ -7,17 +7,17 @@ import { updateHunkRangeAfterExpansion } from '../../src/difflicious/static/js/m
 const buildHunk = (direction) => {
     document.body.innerHTML = `
         <div data-file="src/test.js">
-            <div class="hunk"
+            <div class="js-hunk"
                 data-line-start="10"
                 data-line-end="20"
                 data-left-line-start="5"
                 data-left-line-end="15">
-                <button class="expansion-btn" data-direction="${direction}"></button>
+                <button class="js-expansion-btn" data-direction="${direction}"></button>
             </div>
         </div>
     `;
 
-    return document.querySelector('.expansion-btn');
+    return document.querySelector('.js-expansion-btn');
 };
 
 describe('updateHunkRangeAfterExpansion', () => {
@@ -25,7 +25,7 @@ describe('updateHunkRangeAfterExpansion', () => {
         const button = buildHunk('after');
         updateHunkRangeAfterExpansion(button, 21, 25);
 
-        const hunk = button.closest('.hunk');
+        const hunk = button.closest('.js-hunk');
         expect(hunk.dataset.lineStart).toBe('10');
         expect(hunk.dataset.lineEnd).toBe('25');
         expect(hunk.dataset.leftLineStart).toBe('16');
@@ -36,7 +36,7 @@ describe('updateHunkRangeAfterExpansion', () => {
         const button = buildHunk('before');
         updateHunkRangeAfterExpansion(button, 1, 4);
 
-        const hunk = button.closest('.hunk');
+        const hunk = button.closest('.js-hunk');
         expect(hunk.dataset.lineStart).toBe('1');
         expect(hunk.dataset.lineEnd).toBe('20');
         expect(hunk.dataset.leftLineStart).toBe('1');

--- a/tests/js/full-diff.test.js
+++ b/tests/js/full-diff.test.js
@@ -51,6 +51,6 @@ describe('renderFullDiff', () => {
         };
 
         await renderFullDiff(container, diffData, 'file-1');
-        expect(container.innerHTML).toContain('hunk-lines');
+        expect(container.innerHTML).toContain('js-hunk-lines');
     });
 });


### PR DESCRIPTION
## Summary

Establish a naming convention that makes the Template→JS contract explicit: any CSS class prefixed with `js-` is a **pure JavaScript hook** — it carries zero visual styling, and removing it breaks behaviour not appearance.

Classes renamed:

| Old | New | Used by |
|-----|-----|---------|
| `.expansion-btn` | `.js-expansion-btn` | `main.js`, `hunk-operations.js` (7×) |
| `.hunk-lines` | `.js-hunk-lines` | `context-expansion-ui.js` (4×), `full-diff.js` |
| `.hunk` | `.js-hunk` | `hunk-operations.js` (3×) |
| `.connection-status` | `.js-connection-status` | `auto-reload.js` |

All four classes had **no CSS rules** targeting them directly — confirmed by auditing `styles.css`. Dual-purpose classes with real styling (`.hunk-expansion`, `.file-header`) were intentionally left unchanged.

Updated all usages across: `diff_hunk.html`, `diff_file.html`, five JS modules, and four Jest test files.

## Test plan

- [x] All 142 JS tests pass (`pnpm run test:js`)
- [x] All 148 Python tests pass (`uv run pytest`)
- [x] ESLint clean (`pnpm run lint:js`)
- [x] `./cilicious.sh` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)