### PR TITLE
Lint every JavaScript file, not just the nested ones

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "difflicious",
   "description": "A sleek web-based git diff visualization tool",
   "scripts": {
-    "lint:js": "eslint src/difflicious/static/js/**/*.js",
-    "lint:js:fix": "eslint src/difflicious/static/js/**/*.js --fix",
+    "lint:js": "eslint src/difflicious/static/js",
+    "lint:js:fix": "eslint src/difflicious/static/js --fix",
     "test:js": "NODE_OPTIONS='--experimental-vm-modules' jest",
     "test:js:watch": "NODE_OPTIONS='--experimental-vm-modules' jest --watch",
     "test:js:coverage": "NODE_OPTIONS='--experimental-vm-modules' jest --coverage",

--- a/src/difflicious/static/js/alpine-init.js
+++ b/src/difflicious/static/js/alpine-init.js
@@ -3,14 +3,7 @@
  * Sets up Alpine stores and registers global component factories
  */
 
-// Debug flag - reads from DIFFLICIOUS_DEBUG env var (set in base.html template)
-const DEBUG = window.DIFFLICIOUS_DEBUG || false;
-
-if (DEBUG) console.log('[Alpine] alpine-init.js loading...');
-
 import Alpine from 'alpinejs';
-
-if (DEBUG) console.log('[Alpine] Alpine module imported:', Alpine);
 
 // Import stores
 import diffStore from './stores/diffStore.js';
@@ -23,6 +16,11 @@ import { groupComponent } from './components/groupComponent.js';
 import { searchComponent } from './components/searchComponent.js';
 import { hunkComponent } from './components/hunkComponent.js';
 import { toolbarComponent } from './modules/toolbar.js';
+
+// Debug flag - reads from DIFFLICIOUS_DEBUG env var (set in base.html template)
+const DEBUG = window.DIFFLICIOUS_DEBUG || false;
+
+if (DEBUG) console.log('[Alpine] alpine-init.js loading, Alpine module:', Alpine);
 
 // Register component factories globally BEFORE Alpine starts
 window.fileComponent = fileComponent;
@@ -45,11 +43,13 @@ document.addEventListener('alpine:init', () => {
     Alpine.store('search', searchStore);
     Alpine.store('theme', themeStore);
 
-    if (DEBUG) console.log('[Alpine] Stores registered:', {
-        diff: Alpine.store('diff'),
-        search: Alpine.store('search'),
-        theme: Alpine.store('theme')
-    });
+    if (DEBUG) {
+        console.log('[Alpine] Stores registered:', {
+            diff: Alpine.store('diff'),
+            search: Alpine.store('search'),
+            theme: Alpine.store('theme')
+        });
+    }
 });
 
 // Start Alpine after DOM is ready

--- a/src/difflicious/static/js/main.js
+++ b/src/difflicious/static/js/main.js
@@ -23,7 +23,7 @@ setAutoReloadDebug(DEBUG);
 /**
  * Initialize the application when DOM is ready
  */
-document.addEventListener('DOMContentLoaded', async () => {
+document.addEventListener('DOMContentLoaded', async() => {
     // NOTE: State management handled by Alpine.js stores (diffStore, searchStore, themeStore)
     // via alpine-init.js. Theme, expansion state, and search are all Alpine-managed.
 


### PR DESCRIPTION
## Why

`lint:js` was `eslint src/difflicious/static/js/**/*.js`. npm runs scripts through `sh`, where `**` is not recursive — so eslint only ever saw the 18 files in subdirectories. `alpine-init.js` and `main.js` at the top level have never been linted.

Passing the directory instead lets eslint walk the tree itself, which doesn't depend on the shell's glob support.

## What that surfaced

11 errors in the two unlinted files, all auto-fixable:

- `alpine-init.js` — 9× `import/first` (imports interleaved with debug logging), 1× missing `curly`
- `main.js` — 1× `space-before-function-paren`

ES module imports are hoisted regardless, so reordering them is a no-op at runtime.

## Verification

eslint clean across all 20 files, 142 Jest, 148 pytest. Since the import reordering touches app boot, also smoke-tested in a browser: Alpine stores initialise, diff lines render, no console or page errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)