### PR TITLE
Publish version-tagged Docker images, and stop the description sync failing releases

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -55,17 +55,24 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+    # The semver patterns read the version from github.ref. On a `workflow_run`
+    # event that ref is refs/heads/main, not the tag, so they matched nothing and
+    # every release published only `main` and `latest` — there has never been a
+    # version-tagged image on Docker Hub. `value=` supplies the tag detected
+    # above; on a real tag push it is empty and github.ref is used as before.
     - name: Extract metadata (tags, labels) for Docker
       id: meta
       uses: docker/metadata-action@v5
+      env:
+        RELEASE_TAG: ${{ github.event.release.tag_name || steps.get-tag.outputs.tag }}
       with:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         tags: |
           type=ref,event=branch
           type=ref,event=pr
-          type=semver,pattern={{version}}
-          type=semver,pattern={{major}}.{{minor}}
-          type=semver,pattern={{major}}
+          type=semver,pattern={{version}},value=${{ env.RELEASE_TAG }}
+          type=semver,pattern={{major}}.{{minor}},value=${{ env.RELEASE_TAG }}
+          type=semver,pattern={{major}},value=${{ env.RELEASE_TAG }}
           type=raw,value=latest,enable={{is_default_branch}}
 
     - name: Build and push Docker image
@@ -79,8 +86,15 @@ jobs:
         cache-from: type=gha
         cache-to: type=gha,mode=max
 
+    # Docker Hub's description endpoint needs a token with Read/Write/Delete
+    # (admin) scope, or the account password. A Read & Write token is enough to
+    # log in and push but gets 403 Forbidden here, which is what has been failing
+    # this job while the image itself published fine. Until DOCKER_HUB_TOKEN is
+    # reissued with the wider scope, a failed description sync should not fail a
+    # release that otherwise succeeded.
     - name: Update Docker Hub description
       if: github.event_name != 'pull_request'
+      continue-on-error: true
       uses: peter-evans/dockerhub-description@v4
       with:
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
Looking into the failing Docker job turned up two problems.

## 1. The failure you saw: 403 on the description sync

Everything up to and including **Build and push succeeded** — the image published fine. The only failing step is `Update Docker Hub description`, with `##[error]Forbidden`.

Docker Hub's description endpoint needs a token with **Read/Write/Delete (admin)** scope, or the account password. A **Read & Write** token is enough to `docker login` and push, which is exactly the split we're seeing: push works, `PATCH /v2/repositories/…` gets 403.

**This part needs you** — reissue `DOCKER_HUB_TOKEN` in Docker Hub with Read/Write/Delete scope and update the repo secret. I can't do it from here.

In the meantime the step is `continue-on-error: true`. A README sync shouldn't turn a successful release red.

## 2. The bigger one: no version-tagged images have ever been published

Docker Hub currently holds exactly two tags:

```
latest   updated 2026-08-23
main     updated 2026-08-23
```

No `0.14.0`, no `0.13.0`, nothing — even though `INSTALLATION.md` documents versioned tags.

Cause: the `type=semver` patterns read the version from `github.ref`. This workflow normally runs via `workflow_run` after Auto Release, where `github.ref` is `refs/heads/main`, not the tag — so the semver patterns matched nothing and only `type=ref,event=branch` (`main`) and `latest` were produced.

The job already detects the tag for its checkout step; that value now feeds `metadata-action` too. On a real tag push the override is empty and `github.ref` is used exactly as before.

## Verifying

Merging this won't retroactively tag 0.14.0. To publish it, either re-run the workflow via `workflow_dispatch`, or push the next release tag and confirm `0.14.0`-style tags appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)